### PR TITLE
Add example for viewing contacts key packages

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
+    "applesauce-accounts": "^4.1.0",
     "applesauce-core": "^4.1.0",
     "applesauce-loaders": "^4.0.0",
     "applesauce-relay": "^4.1.0",

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.16
         version: 4.1.16(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      applesauce-accounts:
+        specifier: ^4.1.0
+        version: 4.1.0(typescript@5.9.3)
       applesauce-core:
         specifier: ^4.1.0
         version: 4.1.0(typescript@5.9.3)
@@ -592,6 +595,9 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  applesauce-accounts@4.1.0:
+    resolution: {integrity: sha512-4vRUpkJL8RpVBiboxDb5fUPkeqv+rTIlw3Tog79K1paLHJUcUokcdzzdZLEmS/C531n0AamO2Qvr1XiBFqR5xg==}
 
   applesauce-core@4.1.0:
     resolution: {integrity: sha512-vFOHfqWW4DJfvPkMYLYNiy2ozO2IF+ZNwetGqaLuPjgE1Iwu4trZmG3GJUH+lO1Oq1N4e/OQ/EcotJoEBEiW7Q==}
@@ -1352,6 +1358,18 @@ snapshots:
       vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - supports-color
+
+  applesauce-accounts@4.1.0(typescript@5.9.3):
+    dependencies:
+      '@noble/hashes': 1.8.0
+      applesauce-core: 4.1.0(typescript@5.9.3)
+      applesauce-signers: 4.1.0(typescript@5.9.3)
+      nanoid: 5.1.6
+      nostr-tools: 2.17.0(typescript@5.9.3)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   applesauce-core@4.1.0(typescript@5.9.3):
     dependencies:

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -5,6 +5,7 @@ import SideNav from "./components/SideNav.tsx";
 import { CodeIcon } from "./components/items.tsx";
 import examples, { type Example } from "./examples";
 import useHash from "./hooks/use-hash";
+import SignInModal from "./components/SignInModal.tsx";
 
 function ExampleView(props: { example?: Example }) {
   const [path, setPath] = useState("");
@@ -106,6 +107,8 @@ function ExampleView(props: { example?: Example }) {
 
       {/* Sidebar */}
       <SideNav />
+
+      <SignInModal />
     </div>
   );
 }

--- a/examples/src/components/Accounts.tsx
+++ b/examples/src/components/Accounts.tsx
@@ -1,0 +1,104 @@
+import { useObservable } from "../hooks/use-observable";
+import accountManager from "../lib/accounts";
+import { UserAvatar, UserName } from "./nostr-user";
+
+export default function AccountSwitcher() {
+  const activeAccount = useObservable(accountManager.active$);
+  const accounts = useObservable(accountManager.accounts$);
+
+  const handleSignIn = () => {
+    (document.getElementById("signin_modal") as HTMLDialogElement)?.showModal();
+  };
+
+  const handleSwitchAccount = (accountId: string) => {
+    accountManager.setActive(accountId);
+  };
+
+  const handleSignOut = () => {
+    if (activeAccount) {
+      accountManager.removeAccount(activeAccount.id);
+    }
+  };
+
+  if (!activeAccount) {
+    return (
+      <button className="btn btn-primary w-full" onClick={handleSignIn}>
+        Sign In
+      </button>
+    );
+  }
+
+  const pubkey = activeAccount.pubkey;
+
+  return (
+    <>
+      <div className="dropdown dropdown-top dropdown-end w-full">
+        <div
+          tabIndex={0}
+          role="button"
+          className="flex items-center gap-3 p-2 rounded-lg hover:bg-base-300 cursor-pointer transition-colors w-full"
+        >
+          <UserAvatar pubkey={pubkey} />
+          <div className="flex-1 min-w-0">
+            <div className="font-semibold truncate">
+              <UserName pubkey={pubkey} />
+            </div>
+            <div className="text-xs text-base-content/60 truncate">
+              {pubkey.slice(0, 8)}...{pubkey.slice(-8)}
+            </div>
+          </div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-5 h-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+            />
+          </svg>
+        </div>
+
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu bg-base-200 rounded-box z-1 p-0 w-full border-t-2 border-b-2 border-base-300 pt-2"
+        >
+          {accounts?.map((account) => (
+            <li key={account.id}>
+              <a
+                onClick={() => handleSwitchAccount(account.id)}
+                className={
+                  account.id === activeAccount.id ? "active" : undefined
+                }
+              >
+                <div className="flex items-center gap-2 w-full">
+                  <UserAvatar pubkey={account.pubkey} />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-semibold truncate">
+                      <UserName pubkey={account.pubkey} />
+                    </div>
+                    <div className="text-xs opacity-60 truncate">
+                      {account.pubkey.slice(0, 8)}...
+                      {account.pubkey.slice(-8)}
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </li>
+          ))}
+
+          <li className="border-t border-base-300 my-2 pt-2 ">
+            <a onClick={handleSignIn}>Add Account</a>
+            <a className="text-error" onClick={handleSignOut}>
+              Sign Out
+            </a>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/examples/src/components/BunkerUrlForm.tsx
+++ b/examples/src/components/BunkerUrlForm.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { NostrConnectSigner } from "applesauce-signers";
+import { NostrConnectAccount } from "applesauce-accounts/accounts";
+import accountManager from "../lib/accounts";
+
+export default function BunkerUrlForm() {
+  const [bunkerUrl, setBunkerUrl] = useState("");
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConnect = async () => {
+    if (!bunkerUrl) return;
+
+    try {
+      setIsConnecting(true);
+      setError(null);
+
+      // Create signer from bunker URL
+      const signer = await NostrConnectSigner.fromBunkerURI(bunkerUrl);
+
+      // Get the public key
+      const pubkey = await signer.getPublicKey();
+
+      // Create a NostrConnectAccount
+      const account = new NostrConnectAccount(pubkey, signer);
+
+      // Add the account to the account manager
+      accountManager.addAccount(account);
+
+      // Set it as the active account
+      accountManager.setActive(account.id);
+
+      // Close the modal
+      (document.getElementById("signin_modal") as HTMLDialogElement)?.close();
+
+      // Clear the form
+      setBunkerUrl("");
+    } catch (err) {
+      console.error("Connection error:", err);
+      setError(err instanceof Error ? err.message : "Failed to connect");
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-semibold mb-2">Connect with Bunker URL</h3>
+        <p className="text-sm text-base-content/70 mb-4">
+          Enter your bunker:// URL to connect
+        </p>
+      </div>
+
+      <div className="form-control">
+        <input
+          type="text"
+          placeholder="bunker://..."
+          className="input input-bordered w-full"
+          value={bunkerUrl}
+          onChange={(e) => setBunkerUrl(e.target.value)}
+          disabled={isConnecting}
+        />
+      </div>
+
+      {error && (
+        <div className="alert alert-error">
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+
+      <button
+        className="btn btn-primary w-full"
+        onClick={handleConnect}
+        disabled={!bunkerUrl || isConnecting}
+      >
+        {isConnecting ? (
+          <>
+            <span className="loading loading-spinner"></span>
+            Connecting...
+          </>
+        ) : (
+          "Connect"
+        )}
+      </button>
+    </div>
+  );
+}

--- a/examples/src/components/ExtensionSignIn.tsx
+++ b/examples/src/components/ExtensionSignIn.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { ExtensionSigner } from "applesauce-signers";
+import { ExtensionAccount } from "applesauce-accounts/accounts";
+import accountManager from "../lib/accounts";
+
+interface ExtensionSignInProps {
+  onSuccess?: () => void;
+}
+
+export default function ExtensionSignIn({ onSuccess }: ExtensionSignInProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignInWithExtension = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Create an ExtensionSigner
+      const signer = new ExtensionSigner();
+
+      // Get the public key from the extension
+      const pubkey = await signer.getPublicKey();
+
+      const existing = accountManager.getAccountForPubkey(pubkey);
+      if (existing) {
+        accountManager.setActive(existing.id);
+        onSuccess?.();
+        return;
+      }
+
+      // Create an ExtensionAccount with pubkey and a label
+      const account = new ExtensionAccount(pubkey, signer);
+
+      // Add the account to the account manager
+      accountManager.addAccount(account);
+
+      // Set it as the active account
+      accountManager.setActive(account.id);
+
+      // Call success callback
+      onSuccess?.();
+    } catch (err) {
+      console.error("Sign in error:", err);
+      setError(err instanceof Error ? err.message : "Failed to sign in");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="font-semibold mb-2">Connect with Browser Extension</h4>
+        <p className="text-sm text-base-content/70 mb-4">
+          Use a Nostr extension like Alby or nos2x
+        </p>
+      </div>
+
+      {error && (
+        <div className="alert alert-error">
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+
+      <button
+        className="btn btn-primary w-full"
+        onClick={handleSignInWithExtension}
+        disabled={loading}
+      >
+        {loading ? (
+          <>
+            <span className="loading loading-spinner"></span>
+            Connecting...
+          </>
+        ) : (
+          "Sign in with Extension"
+        )}
+      </button>
+
+      <p className="text-xs text-base-content/50 text-center">
+        Don't have an extension?{" "}
+        <a
+          href="https://getalby.com/alby-extension"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link link-primary"
+        >
+          Get Alby
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/examples/src/components/SideNav.tsx
+++ b/examples/src/components/SideNav.tsx
@@ -1,6 +1,7 @@
 import examples from "../examples";
 import { useState, useMemo } from "react";
 import useHash from "../hooks/use-hash";
+import AccountSwitcher from "./Accounts";
 
 export default function SideNav() {
   const [searchTerm, setSearchTerm] = useState<string>("");
@@ -21,15 +22,17 @@ export default function SideNav() {
         aria-label="open sidebar"
         className="drawer-overlay"
       ></label>
-      <div className="menu bg-base-200 text-base-content min-h-full">
-        <input
-          type="text"
-          placeholder="Search..."
-          className="input input-bordered w-full"
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-        />
-        <ul className="menu menu-lg px-0 font-mono w-xs">
+      <div className="menu bg-base-200 text-base-content min-h-full flex flex-col">
+        <div className="flex-none">
+          <input
+            type="text"
+            placeholder="Search..."
+            className="input input-bordered w-full"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+        <ul className="menu menu-lg px-0 font-mono w-xs flex-1 overflow-y-auto">
           {filtered.map((item) => (
             <li key={item.id}>
               <a
@@ -43,6 +46,7 @@ export default function SideNav() {
             </li>
           ))}
         </ul>
+        <AccountSwitcher />
       </div>
     </div>
   );

--- a/examples/src/components/SignInModal.tsx
+++ b/examples/src/components/SignInModal.tsx
@@ -1,0 +1,65 @@
+import { useRef, useState } from "react";
+import BunkerUrlForm from "./BunkerUrlForm";
+import SignerConnectQR from "./SignerConnectQR";
+import ExtensionSignIn from "./ExtensionSignIn";
+
+export default function SignInModal() {
+  const ref = useRef<HTMLDialogElement>(null);
+  const [activeTab, setActiveTab] = useState<"extension" | "bunker" | "qr">(
+    "extension",
+  );
+
+  const handleSuccess = () => {
+    ref.current?.close();
+  };
+
+  return (
+    <dialog id="signin_modal" className="modal" ref={ref}>
+      <div className="modal-box max-w-lg">
+        <form method="dialog">
+          <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+            ✕
+          </button>
+        </form>
+
+        <h3 className="font-bold text-lg mb-4">Sign In</h3>
+
+        {/* Tabs */}
+        <div role="tablist" className="tabs tabs-border mb-6">
+          <button
+            role="tab"
+            className={`tab ${activeTab === "extension" ? "tab-active" : ""}`}
+            onClick={() => setActiveTab("extension")}
+          >
+            Extension
+          </button>
+          <button
+            role="tab"
+            className={`tab ${activeTab === "bunker" ? "tab-active" : ""}`}
+            onClick={() => setActiveTab("bunker")}
+          >
+            Bunker
+          </button>
+          <button
+            role="tab"
+            className={`tab ${activeTab === "qr" ? "tab-active" : ""}`}
+            onClick={() => setActiveTab("qr")}
+          >
+            QR Code
+          </button>
+        </div>
+
+        {/* Tab Content */}
+        <div>
+          {activeTab === "extension" && (
+            <ExtensionSignIn onSuccess={handleSuccess} />
+          )}
+
+          {activeTab === "bunker" && <BunkerUrlForm />}
+
+          {activeTab === "qr" && <SignerConnectQR />}
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/examples/src/components/SignerConnectQR.tsx
+++ b/examples/src/components/SignerConnectQR.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { NostrConnectSigner } from "applesauce-signers";
+import { NostrConnectAccount } from "applesauce-accounts/accounts";
+import accountManager from "../lib/accounts";
+
+// Simple QR code component using an API
+const QRCode = ({ data }: { data: string }) => (
+  <div className="flex items-center justify-center p-4 bg-white rounded-lg">
+    <img
+      src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(data)}`}
+      alt="QR Code"
+      className="w-48 h-48"
+    />
+  </div>
+);
+
+export default function SignerConnectQR() {
+  const [nostrConnectUri, setNostrConnectUri] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  useEffect(() => {
+    // Generate QR code automatically when component mounts
+    const handleQrCodeLogin = async () => {
+      try {
+        setError(null);
+        setIsConnecting(true);
+
+        // Create a new signer for QR code login
+        const signer = new NostrConnectSigner({
+          relays: ["wss://relay.nsec.app"],
+        });
+
+        // Generate QR code URI with metadata
+        const uri = signer.getNostrConnectURI({
+          name: "Marmot Examples",
+        });
+
+        setNostrConnectUri(uri);
+
+        // Create abort controller for timeout
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5 * 60 * 1000); // 1 minute timeout
+
+        try {
+          // Wait for signer to connect
+          await signer.waitForSigner(controller.signal);
+          clearTimeout(timeoutId);
+
+          // Get the public key
+          const pubkey = await signer.getPublicKey();
+
+          // Create a NostrConnectAccount
+          const account = new NostrConnectAccount(pubkey, signer);
+
+          // Add the account to the account manager
+          accountManager.addAccount(account);
+
+          // Set it as the active account
+          accountManager.setActive(account.id);
+
+          // Close the modal
+          (
+            document.getElementById("signin_modal") as HTMLDialogElement
+          )?.close();
+
+          setNostrConnectUri(null);
+        } catch (err) {
+          console.error("Wait for signer error:", err);
+          if (err instanceof Error && err.message === "Aborted") {
+            setError("Connection timeout. Please try again.");
+          } else {
+            setError(err instanceof Error ? err.message : "Failed to connect");
+          }
+          setNostrConnectUri(null);
+        }
+      } catch (err) {
+        console.error("QR code login error:", err);
+        setError(err instanceof Error ? err.message : "QR code login failed");
+        setNostrConnectUri(null);
+      } finally {
+        setIsConnecting(false);
+      }
+    };
+
+    handleQrCodeLogin();
+  }, []);
+
+  if (isConnecting && !nostrConnectUri) {
+    return (
+      <div className="space-y-4">
+        <div className="text-center">
+          <h3 className="font-semibold mb-2">Generating QR Code</h3>
+          <p className="text-sm text-base-content/70 mb-4">
+            Please wait while we generate your connection code...
+          </p>
+        </div>
+
+        <div className="flex justify-center items-center h-48">
+          <span className="loading loading-spinner loading-lg"></span>
+        </div>
+      </div>
+    );
+  }
+
+  if (nostrConnectUri) {
+    return (
+      <div className="space-y-4">
+        <div className="text-center">
+          <h3 className="font-semibold mb-2">Scan with Mobile Signer</h3>
+          <p className="text-sm text-base-content/70 mb-4">
+            Scan this QR code with your Nostr mobile signer app
+          </p>
+        </div>
+
+        <a target="_blank" href={nostrConnectUri} rel="noopener noreferrer">
+          <QRCode data={nostrConnectUri} />
+        </a>
+
+        <p className="text-xs text-base-content/50 text-center">
+          Waiting for connection...
+        </p>
+
+        {error && (
+          <div className="alert alert-error">
+            <span className="text-sm">{error}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-semibold mb-2">Connect with QR Code</h3>
+        <p className="text-sm text-base-content/70 mb-4">
+          Use a mobile signer app to scan and connect
+        </p>
+      </div>
+
+      {error && (
+        <div className="alert alert-error">
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/src/components/withSignIn.tsx
+++ b/examples/src/components/withSignIn.tsx
@@ -1,0 +1,35 @@
+import { ComponentType } from "react";
+import { useObservable } from "../hooks/use-observable";
+import accountManager from "../lib/accounts";
+
+export function withSignIn<P extends object>(
+  Component: ComponentType<P>,
+): ComponentType<P> {
+  return function WithSignInWrapper(props: P) {
+    const activeAccount = useObservable(accountManager.active$);
+
+    const handleSignIn = () => {
+      (
+        document.getElementById("signin_modal") as HTMLDialogElement
+      )?.showModal();
+    };
+
+    if (!activeAccount) {
+      return (
+        <div className="flex items-center justify-center min-h-[400px] flex-col gap-4">
+          <div className="text-center text-lg">
+            This example requires an account:
+          </div>
+          <button
+            className="btn btn-primary w-sm btn-lg"
+            onClick={handleSignIn}
+          >
+            Sign In
+          </button>
+        </div>
+      );
+    }
+
+    return <Component {...props} />;
+  };
+}

--- a/examples/src/examples/key-package-list/contacts.tsx
+++ b/examples/src/examples/key-package-list/contacts.tsx
@@ -1,0 +1,131 @@
+import { EMPTY, combineLatest, map, switchMap } from "rxjs";
+import {
+  KEY_PACKAGE_RELAY_LIST_KIND,
+  getKeyPackageRelayList,
+} from "../../../../src";
+import { UserAvatar, UserName } from "../../components/nostr-user";
+import { withSignIn } from "../../components/withSignIn";
+import { useObservableMemo } from "../../hooks/use-observable";
+import accounts from "../../lib/accounts";
+import { eventStore } from "../../lib/nostr";
+
+const contacts$ = accounts.active$.pipe(
+  switchMap((account) =>
+    account ? eventStore.contacts(account.pubkey) : EMPTY,
+  ),
+);
+
+function ContactCard(props: { pubkey: string; relays: string[] }) {
+  return (
+    <div className="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
+      <div className="card-body p-4">
+        <div className="flex items-center gap-3 mb-3">
+          <UserAvatar pubkey={props.pubkey} />
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold truncate">
+              <UserName pubkey={props.pubkey} />
+            </h3>
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          {props.relays.map((relay, idx) => (
+            <div
+              key={idx}
+              className="text-xs bg-base-300 rounded px-2 py-1.5 font-mono truncate"
+              title={relay}
+            >
+              {relay}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default withSignIn(() => {
+  const contacts = useObservableMemo(() => contacts$, []);
+
+  // Subscribe to all contact relay lists
+  const contactsWithRelays = useObservableMemo(() => {
+    return contacts$.pipe(
+      switchMap((contacts) => {
+        const relayLists$ = contacts.map((user) =>
+          eventStore.replaceable(KEY_PACKAGE_RELAY_LIST_KIND, user.pubkey).pipe(
+            map((event) => {
+              if (!event) return null;
+              const relays = getKeyPackageRelayList(event);
+              if (relays.length === 0) return null;
+              return { pubkey: user.pubkey, relays };
+            }),
+          ),
+        );
+
+        return combineLatest(relayLists$).pipe(
+          map((results) => results.filter((r) => r !== null)),
+        );
+      }),
+    );
+  }, []);
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Contact Key Package Relays</h1>
+        <p className="text-base-content/70">
+          Contacts who have published a kind 10051 key package relay list.
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="stats shadow">
+        <div className="stat">
+          <div className="stat-title">Total Contacts</div>
+          <div className="stat-value text-primary">{contacts?.length ?? 0}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">With Relay Lists</div>
+          <div className="stat-value text-secondary">
+            {contactsWithRelays?.length ?? 0}
+          </div>
+        </div>
+      </div>
+
+      {/* Empty State */}
+      {contactsWithRelays && contactsWithRelays.length === 0 && (
+        <div className="alert alert-info">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            className="stroke-current shrink-0 w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <span>
+            None of your contacts have published a key package relay list yet.
+          </span>
+        </div>
+      )}
+
+      {/* Grid of Contacts */}
+      {contactsWithRelays && contactsWithRelays.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {contactsWithRelays.map((contact) => (
+            <ContactCard
+              key={contact.pubkey}
+              pubkey={contact.pubkey}
+              relays={contact.relays}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/examples/src/examples/key-package/contacts.tsx
+++ b/examples/src/examples/key-package/contacts.tsx
@@ -1,5 +1,10 @@
 import { mapEventsToTimeline } from "applesauce-core";
-import { NostrEvent, getSeenRelays, kinds } from "applesauce-core/helpers";
+import {
+  NostrEvent,
+  getSeenRelays,
+  kinds,
+  neventEncode,
+} from "applesauce-core/helpers";
 import { EMPTY, combineLatest, map, switchMap, throttleTime } from "rxjs";
 import {
   KEY_PACKAGE_KIND,
@@ -50,19 +55,29 @@ function KeyPackageItem({
         )}
         <span className="text-base-content/60 whitespace-nowrap">{date}</span>
       </div>
-      {seenRelays && (
+
+      <div className="flex items-center gap-2">
         <div className="text-base-content/60 space-x-1">
-          {Array.from(seenRelays).map((relay) => (
-            <span
-              key={relay}
-              className="text-xs bg-base-300 rounded font-mono truncate"
-              title={relay}
-            >
-              {relay.replace(/wss?:\/\//, "").replace(/\/$/, "")}
-            </span>
-          ))}
+          {seenRelays &&
+            Array.from(seenRelays).map((relay) => (
+              <span
+                key={relay}
+                className="text-xs bg-base-300 rounded font-mono truncate"
+                title={relay}
+              >
+                {relay.replace(/wss?:\/\//, "").replace(/\/$/, "")}
+              </span>
+            ))}
         </div>
-      )}
+        <a
+          href={`https://nostr.at/${neventEncode({ id: pkg.id, relays })}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn-xs btn-ghost ms-auto"
+        >
+          View
+        </a>
+      </div>
     </div>
   );
 }

--- a/examples/src/examples/key-package/contacts.tsx
+++ b/examples/src/examples/key-package/contacts.tsx
@@ -1,4 +1,4 @@
-import { mapEventsToTimeline } from "applesauce-core";
+import { mapEventsToStore, mapEventsToTimeline } from "applesauce-core";
 import {
   NostrEvent,
   getSeenRelays,
@@ -98,7 +98,11 @@ function ContactCard(props: { pubkey: string; relays: string[] }) {
             "#k": [String(KEY_PACKAGE_KIND)],
           },
         ])
-        .pipe(mapEventsToTimeline(), throttleTime(100)),
+        .pipe(
+          mapEventsToStore(eventStore),
+          mapEventsToTimeline(),
+          throttleTime(100),
+        ),
     [props.relays.join(","), props.pubkey],
   );
 

--- a/examples/src/lib/accounts.ts
+++ b/examples/src/lib/accounts.ts
@@ -24,12 +24,16 @@ accounts.accounts$.subscribe(() => {
 
 // load active account from storage
 const active = localStorage.getItem("active");
-if (active) accounts.setActive(active);
+if (active) {
+  try {
+    accounts.setActive(active);
+  } catch (error) {}
+}
 
 // subscribe to active changes
 accounts.active$.subscribe((account) => {
   if (account) localStorage.setItem("active", account.id);
-  else localStorage.clearItem("active");
+  else localStorage.removeItem("active");
 });
 
 export default accounts;

--- a/examples/src/lib/accounts.ts
+++ b/examples/src/lib/accounts.ts
@@ -4,32 +4,32 @@ import { NostrConnectSigner } from "applesauce-signers";
 import { pool } from "./nostr";
 
 // create an account manager instance
-const manager = new AccountManager();
+const accounts = new AccountManager();
 
 // register common account types
-registerCommonAccountTypes(manager);
+registerCommonAccountTypes(accounts);
 
 // Setup nostr connect signer
 NostrConnectSigner.pool = pool;
 
 // first load all accounts from localStorage
 const json = JSON.parse(localStorage.getItem("accounts") || "[]");
-await manager.fromJSON(json, true);
+await accounts.fromJSON(json, true);
 
 // next, subscribe to any accounts added or removed
-manager.accounts$.subscribe(() => {
+accounts.accounts$.subscribe(() => {
   // save all the accounts into the "accounts" field
-  localStorage.setItem("accounts", JSON.stringify(manager.toJSON()));
+  localStorage.setItem("accounts", JSON.stringify(accounts.toJSON()));
 });
 
 // load active account from storage
 const active = localStorage.getItem("active");
-if (active) manager.setActive(active);
+if (active) accounts.setActive(active);
 
 // subscribe to active changes
-manager.active$.subscribe((account) => {
+accounts.active$.subscribe((account) => {
   if (account) localStorage.setItem("active", account.id);
   else localStorage.clearItem("active");
 });
 
-export default manager;
+export default accounts;

--- a/examples/src/lib/accounts.ts
+++ b/examples/src/lib/accounts.ts
@@ -1,7 +1,8 @@
-import { AccountManager } from "applesauce-accounts";
+import { AccountManager, SerializedAccount } from "applesauce-accounts";
 import { registerCommonAccountTypes } from "applesauce-accounts/accounts";
 import { NostrConnectSigner } from "applesauce-signers";
 import { pool } from "./nostr";
+import { parse } from "./setting";
 
 // create an account manager instance
 const accounts = new AccountManager();
@@ -13,8 +14,8 @@ registerCommonAccountTypes(accounts);
 NostrConnectSigner.pool = pool;
 
 // first load all accounts from localStorage
-const json = JSON.parse(localStorage.getItem("accounts") || "[]");
-await accounts.fromJSON(json, true);
+const json = parse<SerializedAccount[]>(localStorage.getItem("accounts"));
+if (json) await accounts.fromJSON(json, true);
 
 // next, subscribe to any accounts added or removed
 accounts.accounts$.subscribe(() => {

--- a/examples/src/lib/accounts.ts
+++ b/examples/src/lib/accounts.ts
@@ -1,0 +1,35 @@
+import { AccountManager } from "applesauce-accounts";
+import { registerCommonAccountTypes } from "applesauce-accounts/accounts";
+import { NostrConnectSigner } from "applesauce-signers";
+import { pool } from "./nostr";
+
+// create an account manager instance
+const manager = new AccountManager();
+
+// register common account types
+registerCommonAccountTypes(manager);
+
+// Setup nostr connect signer
+NostrConnectSigner.pool = pool;
+
+// first load all accounts from localStorage
+const json = JSON.parse(localStorage.getItem("accounts") || "[]");
+await manager.fromJSON(json, true);
+
+// next, subscribe to any accounts added or removed
+manager.accounts$.subscribe(() => {
+  // save all the accounts into the "accounts" field
+  localStorage.setItem("accounts", JSON.stringify(manager.toJSON()));
+});
+
+// load active account from storage
+const active = localStorage.getItem("active");
+if (active) manager.setActive(active);
+
+// subscribe to active changes
+manager.active$.subscribe((account) => {
+  if (account) localStorage.setItem("active", account.id);
+  else localStorage.clearItem("active");
+});
+
+export default manager;

--- a/examples/src/lib/nostr.ts
+++ b/examples/src/lib/nostr.ts
@@ -4,6 +4,7 @@ import {
   createEventLoader,
 } from "applesauce-loaders/loaders";
 import { RelayPool } from "applesauce-relay";
+import { lookupRelays$ } from "./setting";
 
 // Create in-memory event store
 export const eventStore = new EventStore();
@@ -13,7 +14,7 @@ export const pool = new RelayPool();
 
 // Create loaders for loading events and replaceable events
 const addressLoader = createAddressLoader(pool, {
-  lookupRelays: ["wss://purplepag.es/", "wss://index.hzrd149.com/"],
+  lookupRelays: lookupRelays$,
 });
 const eventLoader = createEventLoader(pool);
 

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -1,5 +1,13 @@
 import { BehaviorSubject } from "rxjs";
 
+export function parse<T>(value?: string | null): T | undefined {
+  if (value === undefined || value === null) return;
+  try {
+    return JSON.parse(value);
+  } catch {}
+  return;
+}
+
 const DEFAULT_LOOKUP_RELAYS = [
   "wss://purplepag.es/",
   "wss://index.hzrd149.com/",
@@ -7,9 +15,7 @@ const DEFAULT_LOOKUP_RELAYS = [
 ];
 
 export const lookupRelays$ = new BehaviorSubject<string[]>(
-  (localStorage["lookup-relays"] &&
-    JSON.parse(localStorage["lookup-relays"])) ||
-    DEFAULT_LOOKUP_RELAYS,
+  parse(localStorage["lookup-relays"]) || DEFAULT_LOOKUP_RELAYS,
 );
 
 lookupRelays$.subscribe((relays) => {

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -1,0 +1,17 @@
+import { BehaviorSubject } from "rxjs";
+
+const DEFAULT_LOOKUP_RELAYS = [
+  "wss://purplepag.es/",
+  "wss://index.hzrd149.com/",
+  "wss://relay.damus.io/",
+];
+
+export const lookupRelays$ = new BehaviorSubject<string[]>(
+  (localStorage["lookup-relays"] &&
+    JSON.parse(localStorage["lookup-relays"])) ||
+    DEFAULT_LOOKUP_RELAYS,
+);
+
+lookupRelays$.subscribe((relays) => {
+  localStorage["lookup-relays"] = JSON.stringify(relays);
+});

--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -11,6 +11,8 @@ describe("exports", () => {
         "KEY_PACKAGE_KIND",
         "KEY_PACKAGE_MLS_VERSION_TAG",
         "KEY_PACKAGE_RELAYS_TAG",
+        "KEY_PACKAGE_RELAY_LIST_KIND",
+        "KEY_PACKAGE_RELAY_LIST_RELAY_TAG",
         "Marmot",
         "ciphersuite",
         "createCredential",
@@ -20,7 +22,11 @@ describe("exports", () => {
         "getKeyPackageClient",
         "getKeyPackageExtensions",
         "getKeyPackageMLSVersion",
+        "getKeyPackageRelayList",
         "getKeyPackageRelays",
+        "isValidKeyPackageRelayListEvent",
+        "isValidRelayUrl",
+        "normalizeRelayUrl",
       ]
     `);
   });

--- a/src/__tests__/key-package-relays.test.ts
+++ b/src/__tests__/key-package-relays.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from "vitest";
+import {
+  getKeyPackageRelayList,
+  isValidKeyPackageRelayListEvent,
+  KEY_PACKAGE_RELAY_LIST_KIND,
+} from "../helpers/key-package-relay-list.js";
+import { NostrEvent } from "../lib/nostr.js";
+
+const mockPubkey =
+  "02a1633cafe37eeebe2b39b4ec5f3d74c35e61fa7e7e6b7b8c5f7c4f3b2a1b2c3d";
+const mockSig = "304502210...";
+const mockId = "abc123...";
+
+describe("getKeyPackageRelayList", () => {
+  it("should extract and normalize relay URLs from a valid kind 10051 event", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay", "wss://inbox.nostr.wine"],
+        ["relay", "wss://myrelay.nostr1.com"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([
+      "wss://inbox.nostr.wine/",
+      "wss://myrelay.nostr1.com/",
+    ]);
+  });
+
+  it("should return empty array when no relay tags are present", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([]);
+  });
+
+  it("should filter out malformed relay tags and normalize valid ones", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay", "wss://inbox.nostr.wine"],
+        ["relay"], // Missing URL
+        ["relay", ""], // Empty URL
+        ["relay", "wss://myrelay.nostr1.com"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([
+      "wss://inbox.nostr.wine/",
+      "wss://myrelay.nostr1.com/",
+    ]);
+  });
+
+  it("should extract relay tags regardless of event kind", () => {
+    const event: NostrEvent = {
+      kind: 443, // Wrong kind, but function still processes tags
+      tags: [["relay", "wss://inbox.nostr.wine"]],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    // Function doesn't validate kind, so it extracts and normalizes the relay
+    expect(relays).toEqual(["wss://inbox.nostr.wine/"]);
+  });
+
+  it("should ignore non-relay tags and normalize relay URLs", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay", "wss://inbox.nostr.wine"],
+        ["other", "some-value"],
+        ["relay", "wss://myrelay.nostr1.com"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([
+      "wss://inbox.nostr.wine/",
+      "wss://myrelay.nostr1.com/",
+    ]);
+  });
+
+  it("should filter out invalid relay URLs", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay", "wss://valid.relay.com"],
+        ["relay", "not-a-valid-url"],
+        ["relay", "https://wrong-protocol.com"],
+        ["relay", "wss://another.valid.com"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([
+      "wss://valid.relay.com/",
+      "wss://another.valid.com/",
+    ]);
+  });
+
+  it("should preserve paths and query parameters when normalizing", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay", "wss://relay.com/path"],
+        ["relay", "wss://relay.com:8080/path?query=value"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    const relays = getKeyPackageRelayList(event);
+
+    expect(relays).toEqual([
+      "wss://relay.com/path",
+      "wss://relay.com:8080/path?query=value",
+    ]);
+  });
+});
+
+describe("isValidKeyPackageRelayListEvent", () => {
+  it("should return true for a valid kind 10051 event with relay tags", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [["relay", "wss://inbox.nostr.wine"]],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    expect(isValidKeyPackageRelayListEvent(event)).toBe(true);
+  });
+
+  it("should return false for wrong event kind", () => {
+    const event: NostrEvent = {
+      kind: 443,
+      tags: [["relay", "wss://inbox.nostr.wine"]],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    expect(isValidKeyPackageRelayListEvent(event)).toBe(false);
+  });
+
+  it("should return false for event with no relay tags", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    expect(isValidKeyPackageRelayListEvent(event)).toBe(false);
+  });
+
+  it("should return false for event with only malformed relay tags", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [["relay"], ["relay", ""]],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    expect(isValidKeyPackageRelayListEvent(event)).toBe(false);
+  });
+
+  it("should return true even if only one valid relay tag exists", () => {
+    const event: NostrEvent = {
+      kind: 10051,
+      tags: [
+        ["relay"],
+        ["relay", "wss://inbox.nostr.wine"],
+        ["other", "value"],
+      ],
+      content: "",
+      created_at: 1693876543,
+      pubkey: mockPubkey,
+      id: mockId,
+      sig: mockSig,
+    };
+
+    expect(isValidKeyPackageRelayListEvent(event)).toBe(true);
+  });
+});

--- a/src/__tests__/relay-url.test.ts
+++ b/src/__tests__/relay-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isValidRelayUrl, normalizeRelayUrl } from "../helpers/relay-url";
+
+describe("isValidRelayUrl", () => {
+  it("should validate valid WebSocket URLs", () => {
+    expect(isValidRelayUrl("wss://valid.relay.com")).toBe(true);
+    expect(isValidRelayUrl("wss://another.valid.com")).toBe(true);
+  });
+
+  it("should reject invalid URLs", () => {
+    expect(isValidRelayUrl("invalid-url")).toBe(false);
+  });
+
+  it("should accept both wss:// and ws:// protocols", () => {
+    expect(isValidRelayUrl("wss://secure.relay.com")).toBe(true);
+    expect(isValidRelayUrl("ws://insecure.relay.com")).toBe(true);
+  });
+
+  it("should reject non-WebSocket protocols", () => {
+    expect(isValidRelayUrl("https://not-a-websocket.com")).toBe(false);
+    expect(isValidRelayUrl("http://also-not-a-websocket.com")).toBe(false);
+    expect(isValidRelayUrl("ftp://definitely-not.com")).toBe(false);
+  });
+
+  it("should reject completely invalid URLs", () => {
+    expect(isValidRelayUrl("not a url")).toBe(false);
+    expect(isValidRelayUrl("://missing-protocol")).toBe(false);
+    expect(isValidRelayUrl("wss://")).toBe(false);
+  });
+
+  it("should handle URLs with paths and query parameters", () => {
+    expect(isValidRelayUrl("wss://relay.com/path")).toBe(true);
+    expect(isValidRelayUrl("wss://relay.com:8080/path?query=value")).toBe(true);
+  });
+});
+
+describe("normalizeRelayUrl", () => {
+  it("should normalize relay URLs consistently", () => {
+    const url = "wss://relay.com/path";
+    expect(normalizeRelayUrl(url)).toBe("wss://relay.com/path");
+  });
+
+  it("should preserve protocols", () => {
+    expect(normalizeRelayUrl("wss://secure.relay.com")).toBe(
+      "wss://secure.relay.com/",
+    );
+    expect(normalizeRelayUrl("ws://insecure.relay.com")).toBe(
+      "ws://insecure.relay.com/",
+    );
+  });
+
+  it("should preserve ports, paths, and query parameters", () => {
+    expect(normalizeRelayUrl("wss://relay.com:8080/path?query=value")).toBe(
+      "wss://relay.com:8080/path?query=value",
+    );
+  });
+
+  it("should handle trailing slashes consistently", () => {
+    // URL constructor adds trailing slash if no path
+    expect(normalizeRelayUrl("wss://relay.com")).toBe("wss://relay.com/");
+  });
+});

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,4 @@
+export * from "./credential.js";
+export * from "./key-package-relay-list.js";
+export * from "./key-package.js";
+export * from "./relay-url.js";

--- a/src/helpers/key-package-relay-list.ts
+++ b/src/helpers/key-package-relay-list.ts
@@ -1,0 +1,58 @@
+import { NostrEvent } from "../lib/nostr.js";
+import { isValidRelayUrl, normalizeRelayUrl } from "./relay-url.js";
+
+/** Event kind for key package relay list events */
+export const KEY_PACKAGE_RELAY_LIST_KIND = 10051;
+
+/** The name of the tag that contains relay URLs */
+export const KEY_PACKAGE_RELAY_LIST_RELAY_TAG = "relay";
+
+/**
+ * Gets the relay URLs from a kind 10051 event.
+ * These relays indicate where a user publishes their KeyPackages.
+ *
+ * @param event - The kind 10051 event containing relay information
+ * @returns Array of relay URLs, or empty array if none found
+ *
+ * @example
+ * ```typescript
+ * const event = {
+ *   kind: 10051,
+ *   tags: [
+ *     ["relay", "wss://inbox.nostr.wine"],
+ *     ["relay", "wss://myrelay.nostr1.com"]
+ *   ],
+ *   // ... other fields
+ * };
+ * const relays = getKeyPackageRelayList(event);
+ * // Returns: ["wss://inbox.nostr.wine", "wss://myrelay.nostr1.com"]
+ * ```
+ */
+export function getKeyPackageRelayList(event: NostrEvent): string[] {
+  return event.tags
+    .filter((tag) => tag[0] === KEY_PACKAGE_RELAY_LIST_RELAY_TAG && tag[1])
+    .map((tag) => tag[1])
+    .filter(isValidRelayUrl)
+    .map(normalizeRelayUrl);
+}
+
+/**
+ * Validates a kind 10051 relay list event.
+ *
+ * @param event - The event to validate
+ * @returns True if the event is a valid kind 10051 relay list event
+ *
+ * @example
+ * ```typescript
+ * const isValid = isValidKeyPackageRelayListEvent(event);
+ * if (isValid) {
+ *   const relays = getKeyPackageRelayList(event);
+ * }
+ * ```
+ */
+export function isValidKeyPackageRelayListEvent(event: NostrEvent): boolean {
+  return (
+    event.kind === KEY_PACKAGE_RELAY_LIST_KIND &&
+    getKeyPackageRelayList(event).length > 0
+  );
+}

--- a/src/helpers/key-package.ts
+++ b/src/helpers/key-package.ts
@@ -3,6 +3,7 @@ import { ExtensionType, KeyPackage, PrivateKeyPackage } from "ts-mls";
 import { CiphersuiteId, ciphersuites } from "ts-mls/crypto/ciphersuite.js";
 import { decodeKeyPackage } from "ts-mls/keyPackage.js";
 import { getTagValue, NostrEvent } from "../lib/nostr.js";
+import { isValidRelayUrl, normalizeRelayUrl } from "./relay-url.js";
 
 /** Event kind for key package events */
 export const KEY_PACKAGE_KIND = 443;
@@ -100,7 +101,7 @@ export function getKeyPackageExtensions(
 export function getKeyPackageRelays(event: NostrEvent): string[] | undefined {
   const tag = event.tags.find((t) => t[0] === KEY_PACKAGE_RELAYS_TAG);
   if (!tag) return undefined;
-  return tag.slice(1);
+  return tag.slice(1).filter(isValidRelayUrl).map(normalizeRelayUrl);
 }
 
 /** Gets the client for a kind 443 event */

--- a/src/helpers/relay-url.ts
+++ b/src/helpers/relay-url.ts
@@ -1,0 +1,31 @@
+/**
+ * Validates a relay URL to ensure it is a valid WebSocket URL.
+ *
+ * @param relay - Relay URL to validate
+ * @returns True if the relay URL is valid, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const isValid = isValidRelayUrl("wss://valid.relay.com");
+ * // Returns: true
+ *
+ * const isValid = isValidRelayUrl("invalid-url");
+ * // Returns: false
+ * ```
+ */
+export function isValidRelayUrl(relay: string): boolean {
+  if (!URL.canParse(relay)) return false;
+
+  try {
+    const url = new URL(relay);
+    return url.protocol === "wss:" || url.protocol === "ws:";
+  } catch {
+    return false;
+  }
+}
+
+/** Normalizes a relay URL */
+export function normalizeRelayUrl(relay: string): string {
+  const url = new URL(relay);
+  return url.toString();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ import {
 import { createCredential } from "./helpers/credential.js";
 import { CompleteKeyPackage } from "./helpers/key-package.js";
 
-export * from "./helpers/credential.js";
-export * from "./helpers/key-package.js";
+// export all helpers
+export * from "./helpers/index.js";
 
 export const ciphersuite: Ciphersuite = getCiphersuiteFromName(
   "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",


### PR DESCRIPTION
Besides some methods for reading the `kL10051` key package relay list event, this PR mostly just add another example to help explore the key package events that are already out there on relays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-method sign-in modal (extension, bunker URL, QR) and in-layout sign-in entry
  * Account switching, add/remove, persistent storage and auth wrapper for protected screens
  * Configurable lookup relays UI/state and example contacts view for key-package relay data
  * Relay URL validation/normalization and key-package relay-list utilities

* **Tests**
  * Added unit tests for relay URL helpers and key-package relay list handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->