### PR TITLE
refactor(ext): remove explicit default extensions from key packages

### DIFF
--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -21,7 +21,6 @@ describe("exports", () => {
         "createCredential",
         "createKeyPackageEvent",
         "createMarmotGroupData",
-        "createRequiredCapabilitiesExtension",
         "decodeMarmotGroupData",
         "defaultCapabilities",
         "encodeMarmotGroupData",

--- a/src/__tests__/extensions.test.ts
+++ b/src/__tests__/extensions.test.ts
@@ -52,17 +52,22 @@ describe("Key Package Extensions", () => {
       .slice(1)
       .map((ext) => parseInt(ext, 16));
 
-    // Should include required_capabilities (0x0003), ratchet_tree (0x0002), and marmot_group_data (0xf2ee)
-    expect(extensionTypes).toContain(0x0003); // required_capabilities
-    expect(extensionTypes).toContain(0x0002); // ratchet_tree
-    expect(extensionTypes).toContain(0xf2ee); // marmot_group_data
+    // Should only include marmot_group_data (0xf2ee) - default extensions (0x0001-0x0005) are NOT listed
+    // Default extensions: application_id(0x0001), ratchet_tree(0x0002), required_capabilities(0x0003),
+    // external_pub(0x0004), external_senders(0x0005) are implicitly supported by all MLS implementations
+    expect(extensionTypes).not.toContain(0x0001); // application_id (default)
+    expect(extensionTypes).not.toContain(0x0002); // ratchet_tree (default)
+    expect(extensionTypes).not.toContain(0x0003); // required_capabilities (default)
+    expect(extensionTypes).not.toContain(0x0004); // external_pub (default)
+    expect(extensionTypes).not.toContain(0x0005); // external_senders (default)
+    expect(extensionTypes).toContain(0xf2ee); // marmot_group_data (custom)
 
     // Verify we can parse the extensions back using getKeyPackageExtensions
     const parsedExtensions = getKeyPackageExtensions(event as any);
     expect(parsedExtensions).toBeDefined();
-    expect(parsedExtensions!.length).toBe(3);
-    expect(parsedExtensions).toContain(0x0003);
-    expect(parsedExtensions).toContain(0x0002);
+    expect(parsedExtensions!.length).toBe(1); // Only marmot_group_data should be listed
+    expect(parsedExtensions).not.toContain(0x0003);
+    expect(parsedExtensions).not.toContain(0x0002);
     expect(parsedExtensions).toContain(0xf2ee);
   });
 
@@ -96,8 +101,12 @@ describe("Key Package Extensions", () => {
     expect(extensionsTag).toBeDefined();
 
     const extensionHexValues = extensionsTag!.slice(1);
-    expect(extensionHexValues).toContain("0x0003"); // required_capabilities
-    expect(extensionHexValues).toContain("0x0002"); // ratchet_tree
-    expect(extensionHexValues).toContain("0xf2ee"); // marmot_group_data
+    // Should only include marmot_group_data - default extensions are NOT listed
+    expect(extensionHexValues).not.toContain("0x0001"); // application_id (default)
+    expect(extensionHexValues).not.toContain("0x0002"); // ratchet_tree (default)
+    expect(extensionHexValues).not.toContain("0x0003"); // required_capabilities (default)
+    expect(extensionHexValues).not.toContain("0x0004"); // external_pub (default)
+    expect(extensionHexValues).not.toContain("0x0005"); // external_senders (default)
+    expect(extensionHexValues).toContain("0xf2ee"); // marmot_group_data (custom)
   });
 });

--- a/src/core/extensions.ts
+++ b/src/core/extensions.ts
@@ -1,32 +1,5 @@
-import {
-  encodeRequiredCapabilities,
-  Extension,
-  RequiredCapabilities,
-} from "ts-mls";
+import { Extension } from "ts-mls";
 import { MARMOT_GROUP_DATA_EXTENSION_TYPE } from "./protocol.js";
-
-/**
- * Creates required capabilities extension that mandates the Marmot Group Data Extension and ratchet_tree.
- *
- * According to MIP-01, all groups MUST require the Marmot Group Data Extension and ratchet_tree.
- */
-export function createRequiredCapabilitiesExtension(): Extension {
-  const requiredCapabilities: RequiredCapabilities = {
-    extensionTypes: [
-      MARMOT_GROUP_DATA_EXTENSION_TYPE,
-      // TODO: disabled ratchet_tree for now because its not clear if it should be requiring the "default extensions"
-      // see www.rfc-editor.org/rfc/rfc9420.html#section-7.2-4
-      // defaultExtensionTypes.ratchet_tree,
-    ],
-    proposalTypes: [],
-    credentialTypes: ["basic"],
-  };
-
-  return {
-    extensionType: "required_capabilities",
-    extensionData: encodeRequiredCapabilities(requiredCapabilities),
-  };
-}
 
 /**
  * Validates that a key package supports the required Marmot extensions.

--- a/src/core/key-package.ts
+++ b/src/core/key-package.ts
@@ -19,7 +19,6 @@ import {
   MLS_VERSIONS,
   extendedExtensionTypes,
 } from "./protocol.js";
-import { createRequiredCapabilitiesExtension } from "./extensions.js";
 import { createMarmotGroupData } from "./marmot-group-data.js";
 import { NostrEvent } from "applesauce-core/helpers";
 
@@ -98,21 +97,15 @@ export function getKeyPackageClient(
 /**
  * Default extensions for Marmot key packages.
  *
- * According to MIP-01, key packages should support the Marmot Group Data Extension
- * and other standard MLS extensions that groups will require.
+ * According to MIP-00, key packages MUST include the Marmot Group Data Extension.
+ * Default MLS extensions (ratchet_tree, required_capabilities, etc.) are implicitly
+ * supported by all MLS implementations and MUST NOT be listed in capabilities.
  *
  * Key packages MUST include:
- * - required_capabilities (extension type 3) - Defines required MLS features
- * - ratchet_tree (extension type 2) - Manages cryptographic key tree structure
  * - marmot_group_data (extension type 0xF2EE) - Marmot-specific group data
  */
 export function keyPackageDefaultExtensions(): Extension[] {
   return [
-    createRequiredCapabilitiesExtension(),
-    {
-      extensionType: "ratchet_tree",
-      extensionData: new Uint8Array(),
-    },
     {
       extensionType: MARMOT_GROUP_DATA_EXTENSION_TYPE,
       extensionData: createMarmotGroupData({


### PR DESCRIPTION
According to MLS spec, default extensions (ratchet_tree, required_capabilities, etc.) are implicitly supported by all implementations and MUST NOT be listed in capabilities. This removes the explicit creation of required_capabilities and ratchet_tree extensions from keyPackageDefaultExtensions(), relying instead on implicit support.

- Remove createRequiredCapabilitiesExtension() function
- Update tests to expect only custom marmot_group_data extension
- Update keyPackageDefaultExtensions() to only include marmot_group_data
- Remove corresponding imports from key-package.ts and extensions.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified default MLS extensions for key packages to include only essential extensions.
  
* **Breaking Changes**
  * Removed `createRequiredCapabilitiesExtension` from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->