### PR TITLE
feat(config): add global relay configuration system with UI management

### DIFF
--- a/examples/src/components/accounts/picker.tsx
+++ b/examples/src/components/accounts/picker.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import { useObservable } from "../../hooks/use-observable";
 import accountManager from "../../lib/accounts";
 import { UserAvatar, UserName } from "../nostr-user";
+import RelayConfig from "../relay-config";
 
 export default function AccountSwitcher() {
   const activeAccount = useObservable(accountManager.active$);
   const accounts = useObservable(accountManager.accounts$);
+  const [showRelayConfig, setShowRelayConfig] = useState(false);
 
   const handleSignIn = () => {
     (document.getElementById("signin_modal") as HTMLDialogElement)?.showModal();
@@ -109,8 +112,35 @@ export default function AccountSwitcher() {
               </a>
             )}
           </li>
+
+          {/* Relay Configuration */}
+          <li className="border-t border-base-300 pt-2">
+            <a onClick={() => setShowRelayConfig(true)}>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-4 h-4 inline mr-2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75"
+                />
+              </svg>
+              Configure Relays
+            </a>
+          </li>
         </ul>
       </div>
+
+      {/* Relay Configuration Modal */}
+      <RelayConfig
+        isOpen={showRelayConfig}
+        onClose={() => setShowRelayConfig(false)}
+      />
     </>
   );
 }

--- a/examples/src/components/form/relay-picker.tsx
+++ b/examples/src/components/form/relay-picker.tsx
@@ -1,15 +1,6 @@
-import { relaySet } from "applesauce-core/helpers";
 import { useMemo, useState } from "react";
-
-// Common relay URLs that users might want to use
-const COMMON_RELAYS = relaySet([
-  "wss://relay.damus.io",
-  "wss://nos.lol",
-  "wss://relay.primal.net",
-  "wss://relay.nostr.band",
-  "wss://nostr.wine",
-  "wss://relay.snort.social",
-]);
+import { useObservable } from "../../hooks/use-observable";
+import { relayConfig$ } from "../../lib/setting";
 
 function RelayPickerModal(props: {
   isOpen: boolean;
@@ -66,11 +57,13 @@ export default function RelayPicker(props: {
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const relayConfig = useObservable(relayConfig$);
+
   const allRelayOptions = useMemo(() => {
-    const common = props.common || COMMON_RELAYS;
+    const common = props.common || relayConfig?.commonRelays || [];
     if (!props.value || common.includes(props.value)) return common;
     else return [props.value, ...common];
-  }, [props.value, props.common]);
+  }, [props.value, props.common, relayConfig?.commonRelays]);
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     props.onChange(e.target.value);

--- a/examples/src/components/relay-config.tsx
+++ b/examples/src/components/relay-config.tsx
@@ -6,6 +6,9 @@ import {
   updateCommonRelays,
   addManualRelay,
   removeManualRelay,
+  resetLookupRelays,
+  resetCommonRelays,
+  resetManualRelays,
 } from "../lib/setting";
 
 interface RelayConfigProps {
@@ -96,7 +99,16 @@ export default function RelayConfig({ isOpen, onClose }: RelayConfigProps) {
           {/* Lookup Relays Section */}
           <div className="card bg-base-200">
             <div className="card-body p-4">
-              <h4 className="card-title text-sm">Lookup Relays</h4>
+              <div className="flex justify-between items-center mb-3">
+                <h4 className="card-title text-sm">Lookup Relays</h4>
+                <button
+                  className="btn btn-xs btn-outline"
+                  onClick={resetLookupRelays}
+                  title="Reset to default lookup relays"
+                >
+                  Reset
+                </button>
+              </div>
               <p className="text-xs text-base-content/60 mb-3">
                 Used for discovering user profiles and relay lists
               </p>
@@ -140,7 +152,16 @@ export default function RelayConfig({ isOpen, onClose }: RelayConfigProps) {
           {/* Common Relays Section */}
           <div className="card bg-base-200">
             <div className="card-body p-4">
-              <h4 className="card-title text-sm">Common Relays</h4>
+              <div className="flex justify-between items-center mb-3">
+                <h4 className="card-title text-sm">Common Relays</h4>
+                <button
+                  className="btn btn-xs btn-outline"
+                  onClick={resetCommonRelays}
+                  title="Reset to default common relays"
+                >
+                  Reset
+                </button>
+              </div>
               <p className="text-xs text-base-content/60 mb-3">
                 Available in relay picker dropdowns across the app
               </p>
@@ -184,7 +205,16 @@ export default function RelayConfig({ isOpen, onClose }: RelayConfigProps) {
           {/* Manual Relays Section */}
           <div className="card bg-base-200">
             <div className="card-body p-4">
-              <h4 className="card-title text-sm">Manual Relays</h4>
+              <div className="flex justify-between items-center mb-3">
+                <h4 className="card-title text-sm">Manual Relays</h4>
+                <button
+                  className="btn btn-xs btn-outline"
+                  onClick={resetManualRelays}
+                  title="Reset to default manual relays"
+                >
+                  Reset
+                </button>
+              </div>
               <p className="text-xs text-base-content/60 mb-3">
                 Used as fallback when no relay list is found
               </p>

--- a/examples/src/components/relay-config.tsx
+++ b/examples/src/components/relay-config.tsx
@@ -1,0 +1,240 @@
+import { useState } from "react";
+import { useObservable } from "../hooks/use-observable";
+import {
+  relayConfig$,
+  updateLookupRelays,
+  updateCommonRelays,
+  addManualRelay,
+  removeManualRelay,
+} from "../lib/setting";
+
+interface RelayConfigProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function RelayConfig({ isOpen, onClose }: RelayConfigProps) {
+  const relayConfig = useObservable(relayConfig$);
+  const [newLookupRelay, setNewLookupRelay] = useState("");
+  const [newCommonRelay, setNewCommonRelay] = useState("");
+  const [newManualRelay, setNewManualRelay] = useState("");
+
+  if (!relayConfig) return null;
+
+  const handleAddLookupRelay = () => {
+    if (newLookupRelay.trim()) {
+      const newRelays = [
+        ...new Set([...relayConfig.lookupRelays, newLookupRelay.trim()]),
+      ];
+      updateLookupRelays(newRelays);
+      setNewLookupRelay("");
+    }
+  };
+
+  const handleRemoveLookupRelay = (relay: string) => {
+    const newRelays = relayConfig.lookupRelays.filter((r) => r !== relay);
+    updateLookupRelays(newRelays);
+  };
+
+  const handleAddCommonRelay = () => {
+    if (newCommonRelay.trim()) {
+      const newRelays = [
+        ...new Set([...relayConfig.commonRelays, newCommonRelay.trim()]),
+      ];
+      updateCommonRelays(newRelays);
+      setNewCommonRelay("");
+    }
+  };
+
+  const handleRemoveCommonRelay = (relay: string) => {
+    const newRelays = relayConfig.commonRelays.filter((r) => r !== relay);
+    updateCommonRelays(newRelays);
+  };
+
+  const handleAddManualRelay = () => {
+    if (newManualRelay.trim()) {
+      addManualRelay(newManualRelay.trim());
+      setNewManualRelay("");
+    }
+  };
+
+  const handleRemoveManualRelay = (relay: string) => {
+    removeManualRelay(relay);
+  };
+
+  const handleKeyPress = (
+    e: React.KeyboardEvent,
+    type: "lookup" | "common" | "manual",
+  ) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      switch (type) {
+        case "lookup":
+          handleAddLookupRelay();
+          break;
+        case "common":
+          handleAddCommonRelay();
+          break;
+        case "manual":
+          handleAddManualRelay();
+          break;
+      }
+    }
+  };
+
+  return (
+    <dialog className={`modal ${isOpen ? "modal-open" : ""}`}>
+      <div className="modal-box max-w-4xl max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="font-bold text-lg">Relay Configuration</h3>
+          <button className="btn btn-sm btn-circle btn-ghost" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        <div className="space-y-6">
+          {/* Lookup Relays Section */}
+          <div className="card bg-base-200">
+            <div className="card-body p-4">
+              <h4 className="card-title text-sm">Lookup Relays</h4>
+              <p className="text-xs text-base-content/60 mb-3">
+                Used for discovering user profiles and relay lists
+              </p>
+
+              <div className="space-y-2">
+                {relayConfig.lookupRelays.map((relay, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <code className="flex-1 text-xs bg-base-100 p-2 rounded">
+                      {relay}
+                    </code>
+                    <button
+                      className="btn btn-xs btn-error"
+                      onClick={() => handleRemoveLookupRelay(relay)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="join w-full mt-3">
+                <input
+                  type="text"
+                  placeholder="wss://relay.example.com"
+                  className="input input-bordered input-sm join-item flex-1"
+                  value={newLookupRelay}
+                  onChange={(e) => setNewLookupRelay(e.target.value)}
+                  onKeyPress={(e) => handleKeyPress(e, "lookup")}
+                />
+                <button
+                  className="btn btn-primary btn-sm join-item"
+                  onClick={handleAddLookupRelay}
+                  disabled={!newLookupRelay.trim()}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Common Relays Section */}
+          <div className="card bg-base-200">
+            <div className="card-body p-4">
+              <h4 className="card-title text-sm">Common Relays</h4>
+              <p className="text-xs text-base-content/60 mb-3">
+                Available in relay picker dropdowns across the app
+              </p>
+
+              <div className="space-y-2">
+                {relayConfig.commonRelays.map((relay, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <code className="flex-1 text-xs bg-base-100 p-2 rounded">
+                      {relay}
+                    </code>
+                    <button
+                      className="btn btn-xs btn-error"
+                      onClick={() => handleRemoveCommonRelay(relay)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="join w-full mt-3">
+                <input
+                  type="text"
+                  placeholder="wss://relay.example.com"
+                  className="input input-bordered input-sm join-item flex-1"
+                  value={newCommonRelay}
+                  onChange={(e) => setNewCommonRelay(e.target.value)}
+                  onKeyPress={(e) => handleKeyPress(e, "common")}
+                />
+                <button
+                  className="btn btn-primary btn-sm join-item"
+                  onClick={handleAddCommonRelay}
+                  disabled={!newCommonRelay.trim()}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Manual Relays Section */}
+          <div className="card bg-base-200">
+            <div className="card-body p-4">
+              <h4 className="card-title text-sm">Manual Relays</h4>
+              <p className="text-xs text-base-content/60 mb-3">
+                Used as fallback when no relay list is found
+              </p>
+
+              <div className="space-y-2">
+                {relayConfig.manualRelays.map((relay, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <code className="flex-1 text-xs bg-base-100 p-2 rounded">
+                      {relay}
+                    </code>
+                    <button
+                      className="btn btn-xs btn-error"
+                      onClick={() => handleRemoveManualRelay(relay)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="join w-full mt-3">
+                <input
+                  type="text"
+                  placeholder="wss://relay.example.com"
+                  className="input input-bordered input-sm join-item flex-1"
+                  value={newManualRelay}
+                  onChange={(e) => setNewManualRelay(e.target.value)}
+                  onKeyPress={(e) => handleKeyPress(e, "manual")}
+                />
+                <button
+                  className="btn btn-primary btn-sm join-item"
+                  onClick={handleAddManualRelay}
+                  disabled={!newManualRelay.trim()}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-action">
+          <button className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button onClick={onClose}>close</button>
+      </form>
+    </dialog>
+  );
+}

--- a/examples/src/examples/group/metadata.tsx
+++ b/examples/src/examples/group/metadata.tsx
@@ -6,6 +6,8 @@ import {
 } from "../../../../src/core/marmot-group-data";
 import JsonBlock from "../../components/json-block";
 import { MarmotGroupData } from "../../../../src";
+import { relayConfig$ } from "../../lib/setting";
+import { useObservable } from "../../hooks/use-observable";
 
 // ============================================================================
 // Encode Tab Component
@@ -19,7 +21,11 @@ function EncodeTab() {
   const [adminPubkeys, setAdminPubkeys] = useState(
     "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
   );
-  const [relays, setRelays] = useState("wss://relay.damus.io/\nwss://nos.lol/");
+  const relayConfig = useObservable(relayConfig$);
+  const [relays, setRelays] = useState(
+    relayConfig?.manualRelays.join("\n") ||
+      "wss://relay.damus.io/\nwss://nos.lol/",
+  );
   const [encoded, setEncoded] = useState<string>("");
   const [error, setError] = useState<string>("");
 

--- a/examples/src/examples/key-package/create.tsx
+++ b/examples/src/examples/key-package/create.tsx
@@ -36,14 +36,14 @@ import { NostrEvent } from "applesauce-core/helpers";
 import { relayConfig$ } from "../../lib/setting";
 
 /** Observable of current accounts key package relays */
-const keyPackageRelays$ = combineLatest([accounts.active$, mailboxes$]).pipe(
-  switchMap(([account, mailboxes]) =>
+const keyPackageRelays$ = combineLatest([accounts.active$, mailboxes$, relayConfig$]).pipe(
+  switchMap(([account, mailboxes, relayConfig]) =>
     account
       ? eventStore
           .replaceable({
             kind: KEY_PACKAGE_RELAY_LIST_KIND,
             pubkey: account.pubkey,
-            relays: mailboxes?.outboxes,
+            relays: [...(mailboxes?.outboxes || []), ...relayConfig.lookupRelays],
           })
           .pipe(
             map((event) => (event ? getKeyPackageRelayList(event) : undefined)),

--- a/examples/src/examples/key-package/create.tsx
+++ b/examples/src/examples/key-package/create.tsx
@@ -7,11 +7,7 @@ import {
   getCiphersuiteFromName,
   getCiphersuiteImpl,
 } from "ts-mls";
-import {
-  CiphersuiteId,
-  CiphersuiteName,
-  ciphersuites,
-} from "ts-mls/crypto/ciphersuite.js";
+import { CiphersuiteName } from "ts-mls/crypto/ciphersuite.js";
 import { KeyPackage } from "ts-mls/keyPackage.js";
 
 import {
@@ -37,6 +33,7 @@ import accounts, { mailboxes$ } from "../../lib/accounts";
 import { keyPackageStore } from "../../lib/key-package-store";
 import { eventStore, pool } from "../../lib/nostr";
 import { NostrEvent } from "applesauce-core/helpers";
+import { relayConfig$ } from "../../lib/setting";
 
 /** Observable of current accounts key package relays */
 const keyPackageRelays$ = combineLatest([accounts.active$, mailboxes$]).pipe(
@@ -324,12 +321,11 @@ function useKeyPackageCreation() {
       console.log("Generating key package with cipher suite:", cipherSuite);
 
       // Get the cipher suite ID from the name
-      const cipherSuiteId: CiphersuiteId = ciphersuites[cipherSuite];
 
       // TODO: `defaultLifetime` defaults to notBefore: 0n, notAfter: 9223372036854775807n
       const keyPackage = await generateKeyPackage(
         credential,
-        defaultCapabilities(cipherSuiteId),
+        defaultCapabilities(),
         defaultLifetime,
         keyPackageDefaultExtensions(),
         ciphersuiteImpl,
@@ -447,7 +443,10 @@ export default withSignIn(function KeyPackageCreate() {
   // Subscribe to the user's key package relays
   const keyPackageRelays = useObservable(keyPackageRelays$);
 
-  const [relays, setRelays] = useState<string>("wss://relay.damus.io");
+  const relayConfig = useObservable(relayConfig$);
+  const [relays, setRelays] = useState<string>(
+    relayConfig?.manualRelays[0] || "wss://relay.damus.io",
+  );
   const [cipherSuite, setCipherSuite] = useState<CiphersuiteName>(
     "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
   );

--- a/examples/src/examples/key-package/explore.tsx
+++ b/examples/src/examples/key-package/explore.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../../src";
 import { useObservable, useObservableMemo } from "../../hooks/use-observable";
 import { pool } from "../../lib/nostr";
+import { relayConfig$ } from "../../lib/setting";
 
 import CipherSuiteBadge from "../../components/cipher-suite-badge";
 import CredentialTypeBadge from "../../components/credential-type-badge";
@@ -36,7 +37,14 @@ const formatDate = (timestamp: number) => {
   return new Date(timestamp * 1000).toLocaleString();
 };
 
-const relay = new BehaviorSubject<string>("wss://relay.damus.io/");
+// Use first manual relay from global config as default
+const relay = new BehaviorSubject<string>("");
+// Initialize with first manual relay when config is available
+relayConfig$.subscribe((config) => {
+  if (config.manualRelays.length > 0 && !relay.value) {
+    relay.next(config.manualRelays[0]);
+  }
+});
 
 // ============================================================================
 // Key Package Card

--- a/examples/src/examples/key-package/relay-list.tsx
+++ b/examples/src/examples/key-package/relay-list.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { combineLatest, EMPTY, map, switchMap } from "rxjs";
 import { NostrEvent } from "applesauce-core/helpers";
+import { relayConfig$ } from "../../lib/setting";
 import {
   createKeyPackageRelayListEvent,
   getKeyPackageRelayList,
@@ -490,10 +491,13 @@ export default withSignIn(function KeyPackageRelays() {
   const mailboxes = useObservable(mailboxes$);
 
   const [relays, setRelays] = useState<string[]>([]);
+  const relayConfig = useObservable(relayConfig$);
   const [manualRelayInput, setManualRelayInput] = useState(
-    "wss://relay.damus.io/",
+    relayConfig?.manualRelays[0] || "wss://relay.damus.io/",
   );
-  const [manualRelay, setManualRelay] = useState("wss://relay.damus.io/");
+  const [manualRelay, setManualRelay] = useState(
+    relayConfig?.manualRelays[0] || "wss://relay.damus.io/",
+  );
 
   const handleSetManualRelay = () => {
     const newRelay = manualRelayInput.trim();
@@ -537,6 +541,18 @@ export default withSignIn(function KeyPackageRelays() {
 
     return () => subscription.unsubscribe();
   }, [manualRelay]);
+
+  // Update manual relay input when config changes
+  useEffect(() => {
+    if (
+      relayConfig &&
+      Array.isArray(relayConfig.manualRelays) &&
+      relayConfig.manualRelays.length > 0
+    ) {
+      setManualRelayInput(relayConfig.manualRelays[0]);
+      setManualRelay(relayConfig.manualRelays[0]);
+    }
+  }, [relayConfig?.manualRelays]);
 
   const {
     isCreating,

--- a/examples/src/examples/key-package/user-key-packages.tsx
+++ b/examples/src/examples/key-package/user-key-packages.tsx
@@ -5,10 +5,11 @@ import {
   normalizeToPubkey,
   NostrEvent,
 } from "applesauce-core/helpers";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BehaviorSubject, combineLatest, NEVER, of, switchMap } from "rxjs";
 import { map } from "rxjs/operators";
 import { KeyPackage } from "ts-mls";
+import { relayConfig$ } from "../../lib/setting";
 
 import {
   getCredentialPubkey,
@@ -237,6 +238,7 @@ function KeyPackageCard({ event }: { event: NostrEvent }) {
 
 export default function UserKeyPackages() {
   const [pubkeyInput, setPubkeyInput] = useState("");
+  const relayConfig = useObservable(relayConfig$);
   const [manualRelayInput, setManualRelayInput] = useState(
     "wss://relay.damus.io/",
   );
@@ -248,6 +250,18 @@ export default function UserKeyPackages() {
   const handleSetRelay = () => {
     setManualRelay(manualRelayInput);
   };
+
+  // Update manual relay input when config changes
+  useEffect(() => {
+    if (
+      relayConfig &&
+      Array.isArray(relayConfig.manualRelays) &&
+      relayConfig.manualRelays.length > 0
+    ) {
+      setManualRelayInput(relayConfig.manualRelays[0]);
+      setManualRelay(relayConfig.manualRelays[0]);
+    }
+  }, [relayConfig?.manualRelays]);
 
   // Observable for account profiles with display names
   const accountProfiles = useObservableMemo(() => {

--- a/examples/src/lib/accounts.ts
+++ b/examples/src/lib/accounts.ts
@@ -16,7 +16,7 @@ NostrConnectSigner.pool = pool;
 
 // first load all accounts from localStorage
 const json = parse<SerializedAccount[]>(localStorage.getItem("accounts"));
-if (json) await accounts.fromJSON(json, true);
+if (json) accounts.fromJSON(json, true);
 
 // next, subscribe to any accounts added or removed
 accounts.accounts$.subscribe(() => {

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -13,7 +13,6 @@ export function parse<T>(value?: string | null): T | undefined {
 const DEFAULT_LOOKUP_RELAYS = [
   "wss://purplepag.es/",
   "wss://index.hzrd149.com/",
-  "wss://relay.damus.io/",
 ];
 
 const DEFAULT_COMMON_RELAYS = relaySet([

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -1,4 +1,5 @@
 import { BehaviorSubject } from "rxjs";
+import { relaySet } from "applesauce-core/helpers";
 
 export function parse<T>(value?: string | null): T | undefined {
   if (value === undefined || value === null) return;
@@ -8,16 +9,96 @@ export function parse<T>(value?: string | null): T | undefined {
   return;
 }
 
+// Default relay configurations
 const DEFAULT_LOOKUP_RELAYS = [
   "wss://purplepag.es/",
   "wss://index.hzrd149.com/",
   "wss://relay.damus.io/",
 ];
 
+const DEFAULT_COMMON_RELAYS = relaySet([
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.primal.net",
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
+  "wss://relay.snort.social",
+]);
+
+// Global relay configuration
+export interface RelayConfig {
+  lookupRelays: string[];
+  commonRelays: string[];
+  manualRelays: string[];
+}
+
+const DEFAULT_RELAY_CONFIG: RelayConfig = {
+  lookupRelays: DEFAULT_LOOKUP_RELAYS,
+  commonRelays: DEFAULT_COMMON_RELAYS,
+  manualRelays: ["wss://relay.damus.io/"],
+};
+
+// Load relay configuration from localStorage
+const storedConfig = parse<RelayConfig>(localStorage["relay-config"]);
+const initialConfig = storedConfig || DEFAULT_RELAY_CONFIG;
+
+// Observable for the global relay configuration
+export const relayConfig$ = new BehaviorSubject<RelayConfig>(initialConfig);
+
+// Subscribe to save changes to localStorage
+relayConfig$.subscribe((config) => {
+  localStorage["relay-config"] = JSON.stringify(config);
+});
+
+// Helper functions for updating specific parts of the configuration
+export function updateLookupRelays(relays: string[]) {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    lookupRelays: relays,
+  });
+}
+
+export function updateCommonRelays(relays: string[]) {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    commonRelays: relays,
+  });
+}
+
+export function updateManualRelays(relays: string[]) {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    manualRelays: relays,
+  });
+}
+
+export function addManualRelay(relay: string) {
+  const current = relayConfig$.value;
+  const newManualRelays = [...new Set([...current.manualRelays, relay])];
+  relayConfig$.next({
+    ...current,
+    manualRelays: newManualRelays,
+  });
+}
+
+export function removeManualRelay(relay: string) {
+  const current = relayConfig$.value;
+  const newManualRelays = current.manualRelays.filter((r) => r !== relay);
+  relayConfig$.next({
+    ...current,
+    manualRelays: newManualRelays,
+  });
+}
+
+// Backward compatibility - keep lookupRelays$ for existing code
 export const lookupRelays$ = new BehaviorSubject<string[]>(
-  parse(localStorage["lookup-relays"]) || DEFAULT_LOOKUP_RELAYS,
+  initialConfig.lookupRelays,
 );
 
-lookupRelays$.subscribe((relays) => {
-  localStorage["lookup-relays"] = JSON.stringify(relays);
+// Subscribe to keep lookupRelays$ in sync with relayConfig$
+relayConfig$.subscribe((config) => {
+  lookupRelays$.next(config.lookupRelays);
 });

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, map } from "rxjs";
 import { relaySet } from "applesauce-core/helpers";
 
 export function parse<T>(value?: string | null): T | undefined {
@@ -34,7 +34,7 @@ export interface RelayConfig {
 const DEFAULT_RELAY_CONFIG: RelayConfig = {
   lookupRelays: DEFAULT_LOOKUP_RELAYS,
   commonRelays: DEFAULT_COMMON_RELAYS,
-  manualRelays: ["wss://relay.damus.io/"],
+  manualRelays: [],
 };
 
 // Load relay configuration from localStorage
@@ -92,12 +92,32 @@ export function removeManualRelay(relay: string) {
   });
 }
 
-// Backward compatibility - keep lookupRelays$ for existing code
-export const lookupRelays$ = relayConfig$.pipe(map(config => config.lookupRelays))
-  initialConfig.lookupRelays,
-);
+// Reset functions for each relay type
+export function resetLookupRelays() {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    lookupRelays: DEFAULT_LOOKUP_RELAYS,
+  });
+}
 
-// Subscribe to keep lookupRelays$ in sync with relayConfig$
-relayConfig$.subscribe((config) => {
-  lookupRelays$.next(config.lookupRelays);
-});
+export function resetCommonRelays() {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    commonRelays: DEFAULT_COMMON_RELAYS,
+  });
+}
+
+export function resetManualRelays() {
+  const current = relayConfig$.value;
+  relayConfig$.next({
+    ...current,
+    manualRelays: DEFAULT_RELAY_CONFIG.manualRelays,
+  });
+}
+
+// Backward compatibility - keep lookupRelays$ for existing code
+export const lookupRelays$ = relayConfig$.pipe(
+  map((config) => config.lookupRelays),
+);

--- a/examples/src/lib/setting.ts
+++ b/examples/src/lib/setting.ts
@@ -93,7 +93,7 @@ export function removeManualRelay(relay: string) {
 }
 
 // Backward compatibility - keep lookupRelays$ for existing code
-export const lookupRelays$ = new BehaviorSubject<string[]>(
+export const lookupRelays$ = relayConfig$.pipe(map(config => config.lookupRelays))
   initialConfig.lookupRelays,
 );
 


### PR DESCRIPTION
- Create centralized relay configuration management in lib/setting.ts
- Add new RelayConfig component with modal UI for managing:
  - Lookup relays (for user profile discovery)
  - Common relays (available in pickers)
  - Manual relays (fallback relays)
- Integrate configuration across all relay-dependent components:
  - Update account picker to include relay config access
  - Modify relay picker to use dynamic common relays
  - Update group metadata example with config-based relays
  - Enhance key package examples with relay configuration
  - Integrate with existing account management system
- Provide backward compatibility with existing lookupRelays$ observable
- Enable persistent storage via localStorage with automatic synchronization

This change replaces hardcoded relay URLs throughout the application with a dynamic, user-configurable system that allows users to customize their relay preferences through an intuitive interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Relay Configuration modal and a "Configure Relays" option in the account switcher to manage Lookup, Common, and Manual relays.

* **Refactor**
  * Replaced hard-coded relay defaults with a centralized, configurable relay configuration applied across the app and examples.

* **Chores**
  * Persisted and synchronized relay settings globally so defaults and UI now update reactively for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->