### PR TITLE
move group membership methods out to new file

### DIFF
--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -32,7 +32,7 @@ describe("exports", () => {
         "createMarmotGroupData",
         "createSimpleGroup",
         "createThreeMonthLifetime",
-        "createWelcomeEvent",
+        "createWelcomeRumor",
         "decodeContent",
         "decodeMarmotGroupData",
         "defaultCapabilities",
@@ -73,7 +73,6 @@ describe("exports", () => {
         "replacer",
         "serializeClientState",
         "supportsMarmotExtensions",
-        "validateKeyPackageForGroup",
       ]
     `);
   });

--- a/src/core/credential.ts
+++ b/src/core/credential.ts
@@ -1,5 +1,5 @@
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
-import { CredentialBasic } from "ts-mls/credential.js";
+import { Credential, CredentialBasic } from "ts-mls/credential.js";
 
 export function isHexKey(str: string): boolean {
   return /^[0-9a-fA-F]{64}$/.test(str);
@@ -19,7 +19,7 @@ export function createCredential(pubkey: string): CredentialBasic {
 const legacyDecoder = new TextDecoder();
 
 /** Gets the nostr public key from a credential. */
-export function getCredentialPubkey(credential: CredentialBasic): string {
+export function getCredentialPubkey(credential: Credential): string {
   if (credential.credentialType !== "basic")
     throw new Error(
       "Credential is not a basic credential, cannot get nostr public key",

--- a/src/core/group-membership.ts
+++ b/src/core/group-membership.ts
@@ -1,0 +1,141 @@
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { NostrEvent, Rumor, UnsignedEvent } from "applesauce-core/helpers";
+import { EventSigner } from "applesauce-factory";
+import {
+  CiphersuiteImpl,
+  CreateCommitResult,
+  Proposal,
+  createCommit,
+} from "ts-mls";
+import { ClientState } from "ts-mls/clientState.js";
+import { CredentialBasic } from "ts-mls/credential.js";
+import { KeyPackage } from "ts-mls/keyPackage.js";
+import { createGiftWrap } from "../utils/nostr.js";
+import { extractMarmotGroupData } from "./client-state.js";
+import { createGroupEvent } from "./group.js";
+import { createWelcomeEvent } from "./welcome.js";
+
+/**
+ * Result of adding a member to a group with Nostr integration.
+ */
+export interface AddMemberResult {
+  /** The updated ClientState */
+  clientState: ClientState;
+  /** The Nostr commit event that was published */
+  commitEvent: NostrEvent;
+  /** The unsigned welcome event */
+  welcomeEvent: UnsignedEvent;
+  /** The gift-wrapped welcome event (kind 1059) */
+  giftWrapEvent: NostrEvent;
+}
+
+/**
+ * Parameters for adding a member to an existing group with Nostr integration.
+ */
+export interface AddMemberParams {
+  /** The current ClientState */
+  currentClientState: ClientState;
+  /** The key package of the new member to add */
+  newMemberKeyPackage: KeyPackage;
+  /** The cipher suite implementation for cryptographic operations */
+  ciphersuiteImpl: CiphersuiteImpl;
+  /** The event signer for creating gift wraps */
+  signer: EventSigner;
+}
+
+/**
+ * Adds a new member to an existing MLS group with complete Nostr integration.
+ *
+ * This function orchestrates the complete workflow for adding a member:
+ * 1. Creates an Add proposal and Commit using MLS operations
+ * 2. Generates Nostr events (commit and welcome)
+ * 3. Optionally gift-wraps the welcome message for privacy
+ * 4. Returns all events and updated group state
+ *
+ * @param params - Parameters for adding a member with Nostr integration
+ * @returns Promise resolving to the result with events and updated group state
+ * @throws Error if the member addition fails or parameters are invalid
+ */
+export async function addMemberWithNostrIntegration(
+  params: AddMemberParams,
+): Promise<AddMemberResult> {
+  const { currentClientState, newMemberKeyPackage, ciphersuiteImpl, signer } =
+    params;
+
+  // Step 1: Perform MLS member addition
+  const commitResult = await addMemberToGroup(
+    currentClientState,
+    newMemberKeyPackage,
+    ciphersuiteImpl,
+  );
+
+  // Step 2: Create Nostr commit event
+  const marmotData = extractMarmotGroupData(currentClientState);
+  if (!marmotData) {
+    throw new Error("MarmotGroupData not found in ClientState");
+  }
+  const nostrGroupId = bytesToHex(marmotData.nostrGroupId);
+
+  const commitEvent = createGroupEvent(commitResult.commit, nostrGroupId);
+
+  // Step 3: Create welcome event
+  if (!commitResult.welcome) {
+    throw new Error(
+      "Welcome message not generated. This should not happen when adding a member.",
+    );
+  }
+
+  const keyPackageId = bytesToHex(newMemberKeyPackage.initKey);
+  const welcomeEvent = createWelcomeEvent(
+    commitResult.welcome,
+    keyPackageId,
+    await signer.getPublicKey(),
+    marmotData.relays,
+  );
+
+  // Step 4: create gift wrap
+  const giftWrapEvent = await createGiftWrap({
+    rumor: welcomeEvent as Rumor,
+    recipientPubkey: bytesToHex(
+      (newMemberKeyPackage.leafNode.credential as CredentialBasic).identity,
+    ),
+    signer,
+  });
+
+  return {
+    clientState: commitResult.newState,
+    commitEvent,
+    welcomeEvent,
+    giftWrapEvent,
+  };
+}
+
+/**
+ * Adds a new member to an existing MLS group.
+ *
+ * @param currentClientState - The current client state of the group
+ * @param newMemberKeyPackage - The key package of the new member to add
+ * @param ciphersuiteImpl - The cipher suite implementation for cryptographic operations
+ * @returns Promise resolving to the commit, welcome message, and new client state
+ * @throws Error if the member addition fails or parameters are invalid
+ */
+export async function addMemberToGroup(
+  currentClientState: ClientState,
+  newMemberKeyPackage: KeyPackage,
+  ciphersuiteImpl: CiphersuiteImpl,
+): Promise<CreateCommitResult> {
+  // Create an Add proposal for the new member
+  const addProposal: Proposal = {
+    proposalType: "add",
+    add: { keyPackage: newMemberKeyPackage },
+  };
+
+  // Commit the proposal with ratchet tree extension enabled
+  return await createCommit(
+    { state: currentClientState, cipherSuite: ciphersuiteImpl },
+    {
+      extraProposals: [addProposal],
+      ratchetTreeExtension: true,
+    },
+  );
+}

--- a/src/core/group-membership.ts
+++ b/src/core/group-membership.ts
@@ -1,5 +1,5 @@
 import { bytesToHex } from "@noble/hashes/utils.js";
-import { NostrEvent, UnsignedEvent } from "applesauce-core/helpers";
+import { NostrEvent, Rumor } from "applesauce-core/helpers";
 import { EventSigner } from "applesauce-factory";
 import {
   CiphersuiteImpl,
@@ -24,8 +24,8 @@ export interface AddMemberResult {
   clientState: ClientState;
   /** The Nostr commit event that was published */
   commitEvent: NostrEvent;
-  /** The unsigned welcome event */
-  welcomeEvent: UnsignedEvent;
+  /** The welcome rumor with precomputed ID (used for gift-wrapping) */
+  welcomeEvent: Rumor;
   /** The gift-wrapped welcome event (kind 1059) */
   giftWrapEvent: NostrEvent;
 }
@@ -50,7 +50,7 @@ export interface AddMemberParams {
  * This function orchestrates the complete workflow for adding a member:
  * 1. Creates an Add proposal and Commit using MLS operations
  * 2. Generates Nostr events (commit and welcome)
- * 3. Optionally gift-wraps the welcome message for privacy
+ * 3. Gift-wraps the welcome message for privacy
  * 4. Returns all events and updated group state
  *
  * @param params - Parameters for adding a member with Nostr integration

--- a/src/core/group.ts
+++ b/src/core/group.ts
@@ -1,29 +1,16 @@
 import { bytesToHex, randomBytes } from "@noble/hashes/utils.js";
-import { NostrEvent, Rumor, UnsignedEvent } from "applesauce-core/helpers";
-import { EventSigner } from "applesauce-factory";
+import { NostrEvent } from "applesauce-core/helpers";
 import { finalizeEvent, generateSecretKey, getPublicKey } from "nostr-tools";
 import {
   CiphersuiteImpl,
-  CreateCommitResult,
   Extension,
   createGroup as MLSCreateGroup,
-  Proposal,
-  createCommit,
 } from "ts-mls";
 import { ClientState } from "ts-mls/clientState.js";
-import { CredentialBasic } from "ts-mls/credential.js";
-import { KeyPackage } from "ts-mls/keyPackage.js";
 import { encodeMlsMessage, type MLSMessage } from "ts-mls/message.js";
-import { createGiftWrap } from "../utils/nostr.js";
-import { extractMarmotGroupData } from "./client-state.js";
 import { CompleteKeyPackage } from "./key-package.js";
 import { marmotGroupDataToExtension } from "./marmot-group-data.js";
-import {
-  GROUP_EVENT_KIND,
-  MARMOT_GROUP_DATA_EXTENSION_TYPE,
-  MarmotGroupData,
-} from "./protocol.js";
-import { createWelcomeEvent } from "./welcome.js";
+import { GROUP_EVENT_KIND, MarmotGroupData } from "./protocol.js";
 
 /**
  * Parameters for creating a new MLS group.
@@ -45,10 +32,6 @@ export interface CreateGroupParams {
 export interface CreateGroupResult {
   /** The ClientState for the created group */
   clientState: ClientState;
-  /** Welcome message for adding initial members (empty for creator-only group) */
-  welcomeMessage: Uint8Array;
-  /** Initial commit message for group creation */
-  commitMessage: Uint8Array;
 }
 
 /**
@@ -86,39 +69,16 @@ export async function createGroup(
     ciphersuiteImpl,
   );
 
-  // Welcome message is empty for creator-only group
-  const welcomeMessage = new Uint8Array();
-
-  // Initial commit message is empty for creator-only group
-  const commitMessage = new Uint8Array();
-
   return {
     clientState,
-    welcomeMessage,
-    commitMessage,
   };
 }
 
-/**
- * Validates that a key package supports the required Marmot extensions.
- *
- * @param keyPackage - The key package to validate
- * @returns true if the key package supports Marmot extensions
- */
-export function validateKeyPackageForGroup(
-  keyPackage: CompleteKeyPackage,
-): boolean {
-  const extensions = keyPackage.publicPackage.extensions;
-
-  // Check if Marmot Group Data Extension is supported
-  const supportsMarmot = extensions.some(
-    (ext) =>
-      typeof ext.extensionType === "number" &&
-      ext.extensionType === MARMOT_GROUP_DATA_EXTENSION_TYPE,
-  );
-
-  return supportsMarmot;
-}
+export type SimpleGroupOptions = {
+  description?: string;
+  adminPubkeys?: string[];
+  relays?: string[];
+};
 
 /**
  * Creates a simple group with minimal configuration for testing.
@@ -132,11 +92,7 @@ export async function createSimpleGroup(
   creatorKeyPackage: CompleteKeyPackage,
   ciphersuiteImpl: CiphersuiteImpl,
   groupName: string = "New Group",
-  options?: {
-    description?: string;
-    adminPubkeys?: string[];
-    relays?: string[];
-  },
+  options?: SimpleGroupOptions,
 ): Promise<CreateGroupResult> {
   const marmotGroupData: MarmotGroupData = {
     version: 1,
@@ -155,131 +111,6 @@ export async function createSimpleGroup(
     marmotGroupData,
     ciphersuiteImpl,
   });
-}
-
-/**
- * Result of adding a member to a group with Nostr integration.
- */
-export interface AddMemberResult {
-  /** The updated ClientState */
-  clientState: ClientState;
-  /** The Nostr commit event that was published */
-  commitEvent: NostrEvent;
-  /** The unsigned welcome event */
-  welcomeEvent: UnsignedEvent;
-  /** The gift-wrapped welcome event (kind 1059) */
-  giftWrapEvent: NostrEvent;
-}
-
-/**
- * Parameters for adding a member to an existing group with Nostr integration.
- */
-export interface AddMemberParams {
-  /** The current ClientState */
-  currentClientState: ClientState;
-  /** The key package of the new member to add */
-  newMemberKeyPackage: KeyPackage;
-  /** The cipher suite implementation for cryptographic operations */
-  ciphersuiteImpl: CiphersuiteImpl;
-  /** The event signer for creating gift wraps */
-  signer: EventSigner;
-}
-
-/**
- * Adds a new member to an existing MLS group with complete Nostr integration.
- *
- * This function orchestrates the complete workflow for adding a member:
- * 1. Creates an Add proposal and Commit using MLS operations
- * 2. Generates Nostr events (commit and welcome)
- * 3. Optionally gift-wraps the welcome message for privacy
- * 4. Returns all events and updated group state
- *
- * @param params - Parameters for adding a member with Nostr integration
- * @returns Promise resolving to the result with events and updated group state
- * @throws Error if the member addition fails or parameters are invalid
- */
-export async function addMemberWithNostrIntegration(
-  params: AddMemberParams,
-): Promise<AddMemberResult> {
-  const { currentClientState, newMemberKeyPackage, ciphersuiteImpl, signer } =
-    params;
-  console.log("step 1");
-  // Step 1: Perform MLS member addition
-  const commitResult = await addMemberToGroup(
-    currentClientState,
-    newMemberKeyPackage,
-    ciphersuiteImpl,
-  );
-  console.log("step 2");
-  // Step 3: Create Nostr commit event
-  const marmotData = extractMarmotGroupData(currentClientState);
-  if (!marmotData) {
-    throw new Error("MarmotGroupData not found in ClientState");
-  }
-  const nostrGroupId = bytesToHex(marmotData.nostrGroupId);
-
-  const commitEvent = createGroupEvent(commitResult.commit, nostrGroupId);
-  console.log("step 4");
-  // Step 4: Create welcome event
-  if (!commitResult.welcome) {
-    throw new Error(
-      "Welcome message not generated. This should not happen when adding a member.",
-    );
-  }
-
-  const keyPackageId = bytesToHex(newMemberKeyPackage.initKey);
-  const welcomeEvent = createWelcomeEvent(
-    commitResult.welcome,
-    keyPackageId,
-    await signer.getPublicKey(),
-    marmotData.relays,
-  );
-  console.log("step 5");
-  // Step 5: create gift wrap
-  const giftWrapEvent = await createGiftWrap({
-    rumor: welcomeEvent as Rumor,
-    recipientPubkey: bytesToHex(
-      (newMemberKeyPackage.leafNode.credential as CredentialBasic).identity,
-    ),
-    signer,
-  });
-
-  return {
-    clientState: commitResult.newState,
-    commitEvent,
-    welcomeEvent,
-    giftWrapEvent,
-  };
-}
-
-/**
- * Adds a new member to an existing MLS group.
- *
- * @param currentClientState - The current client state of the group
- * @param newMemberKeyPackage - The key package of the new member to add
- * @param ciphersuiteImpl - The cipher suite implementation for cryptographic operations
- * @returns Promise resolving to the commit, welcome message, and new client state
- * @throws Error if the member addition fails or parameters are invalid
- */
-export async function addMemberToGroup(
-  currentClientState: ClientState,
-  newMemberKeyPackage: KeyPackage,
-  ciphersuiteImpl: CiphersuiteImpl,
-): Promise<CreateCommitResult> {
-  // Create an Add proposal for the new member
-  const addProposal: Proposal = {
-    proposalType: "add",
-    add: { keyPackage: newMemberKeyPackage },
-  };
-
-  // Commit the proposal with ratchet tree extension enabled
-  return await createCommit(
-    { state: currentClientState, cipherSuite: ciphersuiteImpl },
-    {
-      extraProposals: [addProposal],
-      ratchetTreeExtension: true,
-    },
-  );
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,7 @@ export * from "./credential.js";
 export * from "./default-capabilities.js";
 export * from "./extensions.js";
 export * from "./group.js";
+export * from "./group-membership.js";
 export * from "./key-package-relay-list.js";
 export * from "./key-package.js";
 export * from "./marmot-group-data.js";

--- a/src/core/welcome.ts
+++ b/src/core/welcome.ts
@@ -10,13 +10,13 @@ import {
 import { WELCOME_EVENT_KIND } from "./protocol.js";
 
 /**
- * Creates an unsigned Nostr event (kind 444) for a welcome message.
+ * Creates a welcome rumor (kind 444) for a welcome message.
  *
  * @param welcomeMessage - The MLS welcome message
  * @param keyPackageEventId - The ID of the key package event used for the add operation
  * @param author - The author's public key (hex string)
  * @param groupRelays - Array of relay URLs for the group
- * @returns Unsigned Nostr event
+ * @returns Welcome rumor with precomputed ID
  */
 export function createWelcomeRumor(
   welcomeMessage: Welcome,

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -1,8 +1,8 @@
 import { NostrEvent, Rumor } from "applesauce-core/helpers";
-import { GiftWrapBlueprint } from "applesauce-factory/blueprints";
-import { EventFactory } from "applesauce-factory";
-import type { GiftWrapOptions } from "applesauce-factory/operations/gift-wrap";
 import type { EventSigner } from "applesauce-factory";
+import { create } from "applesauce-factory";
+import { GiftWrapBlueprint } from "applesauce-factory/blueprints";
+import type { GiftWrapOptions } from "applesauce-factory/operations/gift-wrap";
 
 /** Returns the value of a name / value tag */
 export function getTagValue(
@@ -40,9 +40,12 @@ export async function createGiftWrap(
 ): Promise<NostrEvent> {
   const { rumor, recipientPubkey, signer, opts } = options;
 
-  // Create a factory with the signer
-  const factory = new EventFactory({ signer });
-
   // Use the GiftWrapBlueprint to create the gift wrap
-  return await factory.create(GiftWrapBlueprint, recipientPubkey, rumor, opts);
+  return await create(
+    { signer },
+    GiftWrapBlueprint,
+    recipientPubkey,
+    rumor,
+    opts,
+  );
 }

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -19,7 +19,7 @@ export interface CreateGiftWrapOptions {
   /** The unsigned welcome event (kind 444) to wrap */
   rumor: Rumor;
   /** The recipient's public key (hex string) */
-  recipientPubkey: string;
+  recipient: string;
   /** The signer for creating the gift wrap */
   signer: EventSigner;
   /** Optional gift wrap options */
@@ -38,14 +38,8 @@ export interface CreateGiftWrapOptions {
 export async function createGiftWrap(
   options: CreateGiftWrapOptions,
 ): Promise<NostrEvent> {
-  const { rumor, recipientPubkey, signer, opts } = options;
+  const { rumor, recipient, signer, opts } = options;
 
   // Use the GiftWrapBlueprint to create the gift wrap
-  return await create(
-    { signer },
-    GiftWrapBlueprint,
-    recipientPubkey,
-    rumor,
-    opts,
-  );
+  return await create({ signer }, GiftWrapBlueprint, recipient, rumor, opts);
 }


### PR DESCRIPTION
update create group example to generate new key package by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member addition can use event-pointer (nevent) inputs and event-store lookup; event-based flows for welcomes/gift-wraps added.

* **Refactor**
  * Configuration form now manages its own state and returns a consolidated submission payload.
  * Group creation simplified to a lightweight options object; key-package display now shows nevent identifiers.

* **Bug Fixes**
  * Admin validation blocks unauthorized member additions.

* **Chores**
  * Public API adjustments and renames for welcome/gift artifacts and credential typing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->