### PR TITLE
refactor: api level null image fields

### DIFF
--- a/examples/src/examples/group/metadata.tsx
+++ b/examples/src/examples/group/metadata.tsx
@@ -383,19 +383,19 @@ function DecodeTab() {
               <div>
                 <div className="text-sm font-semibold mb-1">Image Hash</div>
                 <code className="text-xs break-all select-all block">
-                  {bytesToHex(decoded.imageHash)}
+                  {decoded.imageHash ? bytesToHex(decoded.imageHash) : "null"}
                 </code>
               </div>
               <div>
                 <div className="text-sm font-semibold mb-1">Image Key</div>
                 <code className="text-xs break-all select-all block">
-                  {bytesToHex(decoded.imageKey)}
+                  {decoded.imageKey ? bytesToHex(decoded.imageKey) : "null"}
                 </code>
               </div>
               <div>
                 <div className="text-sm font-semibold mb-1">Image Nonce</div>
                 <code className="text-xs break-all select-all block">
-                  {bytesToHex(decoded.imageNonce)}
+                  {decoded.imageNonce ? bytesToHex(decoded.imageNonce) : "null"}
                 </code>
               </div>
             </div>
@@ -412,9 +412,15 @@ function DecodeTab() {
                 value={{
                   ...decoded,
                   nostrGroupId: bytesToHex(decoded.nostrGroupId),
-                  imageHash: bytesToHex(decoded.imageHash),
-                  imageKey: bytesToHex(decoded.imageKey),
-                  imageNonce: bytesToHex(decoded.imageNonce),
+                  imageHash: decoded.imageHash
+                    ? bytesToHex(decoded.imageHash)
+                    : null,
+                  imageKey: decoded.imageKey
+                    ? bytesToHex(decoded.imageKey)
+                    : null,
+                  imageNonce: decoded.imageNonce
+                    ? bytesToHex(decoded.imageNonce)
+                    : null,
                 }}
               />
             </div>

--- a/src/core/group.ts
+++ b/src/core/group.ts
@@ -98,9 +98,9 @@ export async function createSimpleGroup(
     description: options?.description || "",
     adminPubkeys: options?.adminPubkeys || [],
     relays: options?.relays || [],
-    imageHash: new Uint8Array(32),
-    imageKey: new Uint8Array(32),
-    imageNonce: new Uint8Array(12),
+    imageHash: null,
+    imageKey: null,
+    imageNonce: null,
   };
 
   return createGroup({

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -71,11 +71,11 @@ export interface MarmotGroupData {
   /** Array of WebSocket URLs for Nostr relays */
   relays: string[];
   /** SHA-256 hash of the encrypted group image (all zeros if no image) */
-  imageHash: Uint8Array;
+  imageHash: Uint8Array | null;
   /** ChaCha20-Poly1305 encryption key for the group image (all zeros if no image) */
-  imageKey: Uint8Array;
+  imageKey: Uint8Array | null;
   /** ChaCha20-Poly1305 nonce for group image encryption (all zeros if no image) */
-  imageNonce: Uint8Array;
+  imageNonce: Uint8Array | null;
 }
 
 /** Event kind for group events (commits, proposals, application messages) */


### PR DESCRIPTION
Implemented undefined image fields the same way as the Rust MDK pattern: API-level null, TLS-level empty vectors, while keeping the rest of the Marmot Group Data Extension TLS-encoded with length prefixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors caused by missing image metadata fields. The system now safely handles absent data with appropriate null values.

* **Refactor**
  * Image metadata fields are now optional and nullable instead of required. This provides better flexibility when working with incomplete metadata and prevents validation errors for missing image data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->