### PR TITLE
refactor(serialization): migrate client state to binary serialization

### DIFF
--- a/examples/src/components/group-store-modal.tsx
+++ b/examples/src/components/group-store-modal.tsx
@@ -6,11 +6,7 @@ import { ClientState } from "ts-mls/clientState.js";
 import { useObservable, useObservableMemo } from "../hooks/use-observable";
 import { groupStore$ } from "../lib/group-store";
 import ClientStateDataView from "./data-view/client-state";
-import {
-  extractMarmotGroupData,
-  getMemberCount,
-  replacer,
-} from "../../../src/core";
+import { extractMarmotGroupData, getMemberCount } from "../../../src/core";
 
 interface StoredGroupDetailsProps {
   clientState: ClientState;
@@ -37,14 +33,18 @@ function StoredGroupDetails({ clientState, index }: StoredGroupDetailsProps) {
     }
   };
 
-  // Helper function to format MarmotGroupData values for display using the existing replacer
+  // Helper function to format MarmotGroupData values for display
   const formatMarmotDataValue = (value: any): string => {
-    const serialized = JSON.stringify(value, replacer);
-    // Remove the prefixes added by the replacer for display
-    return serialized
-      .replace(/"hex:/g, '"')
-      .replace(/"bigint:/g, '"')
-      .replace(/"/g, "");
+    if (value instanceof Uint8Array) {
+      return bytesToHex(value);
+    }
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    if (value instanceof Map) {
+      return JSON.stringify(Object.fromEntries(value));
+    }
+    return JSON.stringify(value);
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -53,18 +53,18 @@
   },
   "dependencies": {
     "@hpke/core": "^1.7.5",
-    "@noble/ciphers": "^2.0.1",
+    "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "applesauce-core": "^4.4.2",
     "applesauce-factory": "^4.0.0",
-    "nostr-tools": "^2.19.3",
-    "ts-mls": "^1.4.3"
+    "nostr-tools": "^2.19.4",
+    "ts-mls": "^1.5.0"
   },
   "devDependencies": {
-    "@types/node": "^24.10.1",
+    "@types/node": "^24.10.4",
     "husky": "^9.1.7",
-    "prettier": "^3.7.3",
+    "prettier": "^3.7.4",
     "rimraf": "~6.0.1",
     "typescript": "~5.9.3",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^1.7.5
         version: 1.7.5
       "@noble/ciphers":
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.1.1
+        version: 2.1.1
       "@noble/curves":
         specifier: ^2.0.1
         version: 2.0.1
@@ -26,21 +26,21 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(typescript@5.9.3)
       nostr-tools:
-        specifier: ^2.19.3
-        version: 2.19.3(typescript@5.9.3)
+        specifier: ^2.19.4
+        version: 2.19.4(typescript@5.9.3)
       ts-mls:
-        specifier: ^1.4.3
-        version: 1.4.3(@noble/ciphers@2.0.1)(@noble/curves@2.0.1)
+        specifier: ^1.5.0
+        version: 1.5.0(@noble/ciphers@2.1.1)(@noble/curves@2.0.1)
     devDependencies:
       "@types/node":
-        specifier: ^24.10.1
-        version: 24.10.1
+        specifier: ^24.10.4
+        version: 24.10.4
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       prettier:
-        specifier: ^3.7.3
-        version: 3.7.3
+        specifier: ^3.7.4
+        version: 3.7.4
       rimraf:
         specifier: ~6.0.1
         version: 6.0.1
@@ -49,7 +49,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6)
 
 packages:
   "@cashu/cashu-ts@2.8.1":
@@ -68,10 +68,28 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/android-arm64@0.25.12":
     resolution:
       {
         integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -86,10 +104,28 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.27.2":
+    resolution:
+      {
+        integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-x64@0.25.12":
     resolution:
       {
         integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -104,10 +140,28 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.25.12":
     resolution:
       {
         integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -122,10 +176,28 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.25.12":
     resolution:
       {
         integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -140,10 +212,28 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm@0.25.12":
     resolution:
       {
         integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.27.2":
+    resolution:
+      {
+        integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
@@ -158,10 +248,28 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.27.2":
+    resolution:
+      {
+        integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.25.12":
     resolution:
       {
         integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
@@ -176,10 +284,28 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.27.2":
+    resolution:
+      {
+        integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.25.12":
     resolution:
       {
         integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
@@ -194,10 +320,28 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.25.12":
     resolution:
       {
         integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.27.2":
+    resolution:
+      {
+        integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
@@ -212,10 +356,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/linux-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
   "@esbuild/netbsd-arm64@0.25.12":
     resolution:
       {
         integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -230,10 +392,28 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/netbsd-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
   "@esbuild/openbsd-arm64@0.25.12":
     resolution:
       {
         integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -248,10 +428,28 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  "@esbuild/openbsd-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
   "@esbuild/openharmony-arm64@0.25.12":
     resolution:
       {
         integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/openharmony-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -266,10 +464,28 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/win32-arm64@0.25.12":
     resolution:
       {
         integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -284,10 +500,28 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.27.2":
+    resolution:
+      {
+        integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-x64@0.25.12":
     resolution:
       {
         integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.27.2":
+    resolution:
+      {
+        integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -340,10 +574,10 @@ packages:
         integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==,
       }
 
-  "@noble/ciphers@2.0.1":
+  "@noble/ciphers@2.1.1":
     resolution:
       {
-        integrity: sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==,
+        integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==,
       }
     engines: { node: ">= 20.19.0" }
 
@@ -401,178 +635,178 @@ packages:
       }
     engines: { node: ">= 20.19.0" }
 
-  "@rollup/rollup-android-arm-eabi@4.53.3":
+  "@rollup/rollup-android-arm-eabi@4.54.0":
     resolution:
       {
-        integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==,
+        integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==,
       }
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.53.3":
+  "@rollup/rollup-android-arm64@4.54.0":
     resolution:
       {
-        integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==,
+        integrity: sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==,
       }
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.53.3":
+  "@rollup/rollup-darwin-arm64@4.54.0":
     resolution:
       {
-        integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==,
+        integrity: sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.53.3":
+  "@rollup/rollup-darwin-x64@4.54.0":
     resolution:
       {
-        integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==,
+        integrity: sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.53.3":
+  "@rollup/rollup-freebsd-arm64@4.54.0":
     resolution:
       {
-        integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==,
+        integrity: sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==,
       }
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.53.3":
+  "@rollup/rollup-freebsd-x64@4.54.0":
     resolution:
       {
-        integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==,
+        integrity: sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.53.3":
+  "@rollup/rollup-linux-arm-gnueabihf@4.54.0":
     resolution:
       {
-        integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==,
+        integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.53.3":
+  "@rollup/rollup-linux-arm-musleabihf@4.54.0":
     resolution:
       {
-        integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==,
+        integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.53.3":
+  "@rollup/rollup-linux-arm64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==,
+        integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.53.3":
+  "@rollup/rollup-linux-arm64-musl@4.54.0":
     resolution:
       {
-        integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==,
+        integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-gnu@4.53.3":
+  "@rollup/rollup-linux-loong64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==,
+        integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==,
       }
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.53.3":
+  "@rollup/rollup-linux-ppc64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==,
+        integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==,
       }
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.53.3":
+  "@rollup/rollup-linux-riscv64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==,
+        integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.53.3":
+  "@rollup/rollup-linux-riscv64-musl@4.54.0":
     resolution:
       {
-        integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==,
+        integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.53.3":
+  "@rollup/rollup-linux-s390x-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==,
+        integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==,
       }
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.53.3":
+  "@rollup/rollup-linux-x64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==,
+        integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.53.3":
+  "@rollup/rollup-linux-x64-musl@4.54.0":
     resolution:
       {
-        integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==,
+        integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-openharmony-arm64@4.53.3":
+  "@rollup/rollup-openharmony-arm64@4.54.0":
     resolution:
       {
-        integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==,
+        integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==,
       }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.53.3":
+  "@rollup/rollup-win32-arm64-msvc@4.54.0":
     resolution:
       {
-        integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==,
+        integrity: sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==,
       }
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.53.3":
+  "@rollup/rollup-win32-ia32-msvc@4.54.0":
     resolution:
       {
-        integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==,
+        integrity: sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==,
       }
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.53.3":
+  "@rollup/rollup-win32-x64-gnu@4.54.0":
     resolution:
       {
-        integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==,
+        integrity: sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.53.3":
+  "@rollup/rollup-win32-x64-msvc@4.54.0":
     resolution:
       {
-        integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==,
+        integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==,
       }
     cpu: [x64]
     os: [win32]
@@ -649,10 +883,10 @@ packages:
         integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
       }
 
-  "@types/node@24.10.1":
+  "@types/node@24.10.4":
     resolution:
       {
-        integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==,
+        integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==,
       }
 
   "@types/unist@3.0.3":
@@ -887,6 +1121,14 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
+  esbuild@0.27.2:
+    resolution:
+      {
+        integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
   escape-string-regexp@5.0.0:
     resolution:
       {
@@ -900,10 +1142,10 @@ packages:
         integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
       }
 
-  expect-type@1.2.2:
+  expect-type@1.3.0:
     resolution:
       {
-        integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==,
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -1248,10 +1490,10 @@ packages:
       typescript:
         optional: true
 
-  nostr-tools@2.19.3:
+  nostr-tools@2.19.4:
     resolution:
       {
-        integrity: sha512-IJ1fcTYAfVVUbS8S/FtDopdPHCDh/34aHXnyppUzXDYGWlJMv2y1phomvOADZrMAQ6Z28iOIBEyGY256w1492Q==,
+        integrity: sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg==,
       }
     peerDependencies:
       typescript: ">=5.0.0"
@@ -1318,10 +1560,10 @@ packages:
       }
     engines: { node: ^10 || ^12 || >=14 }
 
-  prettier@3.7.3:
+  prettier@3.7.4:
     resolution:
       {
-        integrity: sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==,
+        integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -1358,10 +1600,10 @@ packages:
     engines: { node: 20 || >=22 }
     hasBin: true
 
-  rollup@4.53.3:
+  rollup@4.54.0:
     resolution:
       {
-        integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==,
+        integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==,
       }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
@@ -1498,16 +1740,16 @@ packages:
         integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
       }
 
-  ts-mls@1.4.3:
+  ts-mls@1.5.0:
     resolution:
       {
-        integrity: sha512-Suarl/GV93qr8bdnZsbMb0BqTHDjJZdd4mRi5oHpn5qDCT/LBosEYe3h2UvbKUs9WLGO80inK+eet+oCBzABSQ==,
+        integrity: sha512-hfizW36GtJ69NrUDOLdAqErkP6jSEJ/N15siFrTRiDOXsCEAQcu2AiJiXootj3xWORqc94Zr4U8XTLNblKJq4A==,
       }
     peerDependencies:
       "@hpke/chacha20poly1305": 1.7.1
       "@hpke/hybridkem-x-wing": 0.6.1
       "@hpke/ml-kem": 0.2.1
-      "@noble/ciphers": 2.0.1
+      "@noble/ciphers": 2.1.1
       "@noble/curves": 2.0.1
       "@noble/post-quantum": 0.5.2
     peerDependenciesMeta:
@@ -1600,10 +1842,10 @@ packages:
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
 
-  vite@7.2.6:
+  vite@7.3.0:
     resolution:
       {
-        integrity: sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==,
+        integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -1720,79 +1962,157 @@ snapshots:
   "@esbuild/aix-ppc64@0.25.12":
     optional: true
 
+  "@esbuild/aix-ppc64@0.27.2":
+    optional: true
+
   "@esbuild/android-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/android-arm64@0.27.2":
     optional: true
 
   "@esbuild/android-arm@0.25.12":
     optional: true
 
+  "@esbuild/android-arm@0.27.2":
+    optional: true
+
   "@esbuild/android-x64@0.25.12":
+    optional: true
+
+  "@esbuild/android-x64@0.27.2":
     optional: true
 
   "@esbuild/darwin-arm64@0.25.12":
     optional: true
 
+  "@esbuild/darwin-arm64@0.27.2":
+    optional: true
+
   "@esbuild/darwin-x64@0.25.12":
+    optional: true
+
+  "@esbuild/darwin-x64@0.27.2":
     optional: true
 
   "@esbuild/freebsd-arm64@0.25.12":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.27.2":
+    optional: true
+
   "@esbuild/freebsd-x64@0.25.12":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.27.2":
     optional: true
 
   "@esbuild/linux-arm64@0.25.12":
     optional: true
 
+  "@esbuild/linux-arm64@0.27.2":
+    optional: true
+
   "@esbuild/linux-arm@0.25.12":
+    optional: true
+
+  "@esbuild/linux-arm@0.27.2":
     optional: true
 
   "@esbuild/linux-ia32@0.25.12":
     optional: true
 
+  "@esbuild/linux-ia32@0.27.2":
+    optional: true
+
   "@esbuild/linux-loong64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-loong64@0.27.2":
     optional: true
 
   "@esbuild/linux-mips64el@0.25.12":
     optional: true
 
+  "@esbuild/linux-mips64el@0.27.2":
+    optional: true
+
   "@esbuild/linux-ppc64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.27.2":
     optional: true
 
   "@esbuild/linux-riscv64@0.25.12":
     optional: true
 
+  "@esbuild/linux-riscv64@0.27.2":
+    optional: true
+
   "@esbuild/linux-s390x@0.25.12":
+    optional: true
+
+  "@esbuild/linux-s390x@0.27.2":
     optional: true
 
   "@esbuild/linux-x64@0.25.12":
     optional: true
 
+  "@esbuild/linux-x64@0.27.2":
+    optional: true
+
   "@esbuild/netbsd-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.27.2":
     optional: true
 
   "@esbuild/netbsd-x64@0.25.12":
     optional: true
 
+  "@esbuild/netbsd-x64@0.27.2":
+    optional: true
+
   "@esbuild/openbsd-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.27.2":
     optional: true
 
   "@esbuild/openbsd-x64@0.25.12":
     optional: true
 
+  "@esbuild/openbsd-x64@0.27.2":
+    optional: true
+
   "@esbuild/openharmony-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.27.2":
     optional: true
 
   "@esbuild/sunos-x64@0.25.12":
     optional: true
 
+  "@esbuild/sunos-x64@0.27.2":
+    optional: true
+
   "@esbuild/win32-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/win32-arm64@0.27.2":
     optional: true
 
   "@esbuild/win32-ia32@0.25.12":
     optional: true
 
+  "@esbuild/win32-ia32@0.27.2":
+    optional: true
+
   "@esbuild/win32-x64@0.25.12":
+    optional: true
+
+  "@esbuild/win32-x64@0.27.2":
     optional: true
 
   "@hpke/common@1.8.1": {}
@@ -1820,7 +2140,7 @@ snapshots:
 
   "@noble/ciphers@0.5.3": {}
 
-  "@noble/ciphers@2.0.1": {}
+  "@noble/ciphers@2.1.1": {}
 
   "@noble/curves@1.1.0":
     dependencies:
@@ -1846,70 +2166,70 @@ snapshots:
 
   "@noble/hashes@2.0.1": {}
 
-  "@rollup/rollup-android-arm-eabi@4.53.3":
+  "@rollup/rollup-android-arm-eabi@4.54.0":
     optional: true
 
-  "@rollup/rollup-android-arm64@4.53.3":
+  "@rollup/rollup-android-arm64@4.54.0":
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.53.3":
+  "@rollup/rollup-darwin-arm64@4.54.0":
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.53.3":
+  "@rollup/rollup-darwin-x64@4.54.0":
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.53.3":
+  "@rollup/rollup-freebsd-arm64@4.54.0":
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.53.3":
+  "@rollup/rollup-freebsd-x64@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.53.3":
+  "@rollup/rollup-linux-arm-gnueabihf@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.53.3":
+  "@rollup/rollup-linux-arm-musleabihf@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.53.3":
+  "@rollup/rollup-linux-arm64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.53.3":
+  "@rollup/rollup-linux-arm64-musl@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.53.3":
+  "@rollup/rollup-linux-loong64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.53.3":
+  "@rollup/rollup-linux-ppc64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.53.3":
+  "@rollup/rollup-linux-riscv64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.53.3":
+  "@rollup/rollup-linux-riscv64-musl@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.53.3":
+  "@rollup/rollup-linux-s390x-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.53.3":
+  "@rollup/rollup-linux-x64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.53.3":
+  "@rollup/rollup-linux-x64-musl@4.54.0":
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.53.3":
+  "@rollup/rollup-openharmony-arm64@4.54.0":
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.53.3":
+  "@rollup/rollup-win32-arm64-msvc@4.54.0":
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.53.3":
+  "@rollup/rollup-win32-ia32-msvc@4.54.0":
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.53.3":
+  "@rollup/rollup-win32-x64-gnu@4.54.0":
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.53.3":
+  "@rollup/rollup-win32-x64-msvc@4.54.0":
     optional: true
 
   "@scure/base@1.1.1": {}
@@ -1919,7 +2239,7 @@ snapshots:
   "@scure/bip32@1.3.1":
     dependencies:
       "@noble/curves": 1.1.0
-      "@noble/hashes": 1.3.2
+      "@noble/hashes": 1.3.1
       "@scure/base": 1.1.1
 
   "@scure/bip32@1.7.0":
@@ -1930,7 +2250,7 @@ snapshots:
 
   "@scure/bip39@1.2.1":
     dependencies:
-      "@noble/hashes": 1.3.2
+      "@noble/hashes": 1.3.1
       "@scure/base": 1.1.1
 
   "@types/chai@5.2.3":
@@ -1956,7 +2276,7 @@ snapshots:
 
   "@types/ms@2.1.0": {}
 
-  "@types/node@24.10.1":
+  "@types/node@24.10.4":
     dependencies:
       undici-types: 7.16.0
 
@@ -1970,13 +2290,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6))":
+  "@vitest/mocker@3.2.4(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6))":
     dependencies:
       "@vitest/spy": 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6)
 
   "@vitest/pretty-format@3.2.4":
     dependencies:
@@ -2051,7 +2371,7 @@ snapshots:
       applesauce-content: 4.0.0(typescript@5.9.3)
       applesauce-core: 4.4.2(typescript@5.9.3)
       nanoid: 5.1.6
-      nostr-tools: 2.19.3(typescript@5.9.3)
+      nostr-tools: 2.19.4(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2138,6 +2458,36 @@ snapshots:
       "@esbuild/win32-arm64": 0.25.12
       "@esbuild/win32-ia32": 0.25.12
       "@esbuild/win32-x64": 0.25.12
+    optional: true
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.27.2
+      "@esbuild/android-arm": 0.27.2
+      "@esbuild/android-arm64": 0.27.2
+      "@esbuild/android-x64": 0.27.2
+      "@esbuild/darwin-arm64": 0.27.2
+      "@esbuild/darwin-x64": 0.27.2
+      "@esbuild/freebsd-arm64": 0.27.2
+      "@esbuild/freebsd-x64": 0.27.2
+      "@esbuild/linux-arm": 0.27.2
+      "@esbuild/linux-arm64": 0.27.2
+      "@esbuild/linux-ia32": 0.27.2
+      "@esbuild/linux-loong64": 0.27.2
+      "@esbuild/linux-mips64el": 0.27.2
+      "@esbuild/linux-ppc64": 0.27.2
+      "@esbuild/linux-riscv64": 0.27.2
+      "@esbuild/linux-s390x": 0.27.2
+      "@esbuild/linux-x64": 0.27.2
+      "@esbuild/netbsd-arm64": 0.27.2
+      "@esbuild/netbsd-x64": 0.27.2
+      "@esbuild/openbsd-arm64": 0.27.2
+      "@esbuild/openbsd-x64": 0.27.2
+      "@esbuild/openharmony-arm64": 0.27.2
+      "@esbuild/sunos-x64": 0.27.2
+      "@esbuild/win32-arm64": 0.27.2
+      "@esbuild/win32-ia32": 0.27.2
+      "@esbuild/win32-x64": 0.27.2
 
   escape-string-regexp@5.0.0: {}
 
@@ -2145,7 +2495,7 @@ snapshots:
     dependencies:
       "@types/estree": 1.0.8
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -2412,7 +2762,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  nostr-tools@2.19.3(typescript@5.9.3):
+  nostr-tools@2.19.4(typescript@5.9.3):
     dependencies:
       "@noble/ciphers": 0.5.3
       "@noble/curves": 1.2.0
@@ -2449,7 +2799,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.7.3: {}
+  prettier@3.7.4: {}
 
   remark-parse@11.0.0:
     dependencies:
@@ -2483,32 +2833,32 @@ snapshots:
       glob: 11.1.0
       package-json-from-dist: 1.0.1
 
-  rollup@4.53.3:
+  rollup@4.54.0:
     dependencies:
       "@types/estree": 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.53.3
-      "@rollup/rollup-android-arm64": 4.53.3
-      "@rollup/rollup-darwin-arm64": 4.53.3
-      "@rollup/rollup-darwin-x64": 4.53.3
-      "@rollup/rollup-freebsd-arm64": 4.53.3
-      "@rollup/rollup-freebsd-x64": 4.53.3
-      "@rollup/rollup-linux-arm-gnueabihf": 4.53.3
-      "@rollup/rollup-linux-arm-musleabihf": 4.53.3
-      "@rollup/rollup-linux-arm64-gnu": 4.53.3
-      "@rollup/rollup-linux-arm64-musl": 4.53.3
-      "@rollup/rollup-linux-loong64-gnu": 4.53.3
-      "@rollup/rollup-linux-ppc64-gnu": 4.53.3
-      "@rollup/rollup-linux-riscv64-gnu": 4.53.3
-      "@rollup/rollup-linux-riscv64-musl": 4.53.3
-      "@rollup/rollup-linux-s390x-gnu": 4.53.3
-      "@rollup/rollup-linux-x64-gnu": 4.53.3
-      "@rollup/rollup-linux-x64-musl": 4.53.3
-      "@rollup/rollup-openharmony-arm64": 4.53.3
-      "@rollup/rollup-win32-arm64-msvc": 4.53.3
-      "@rollup/rollup-win32-ia32-msvc": 4.53.3
-      "@rollup/rollup-win32-x64-gnu": 4.53.3
-      "@rollup/rollup-win32-x64-msvc": 4.53.3
+      "@rollup/rollup-android-arm-eabi": 4.54.0
+      "@rollup/rollup-android-arm64": 4.54.0
+      "@rollup/rollup-darwin-arm64": 4.54.0
+      "@rollup/rollup-darwin-x64": 4.54.0
+      "@rollup/rollup-freebsd-arm64": 4.54.0
+      "@rollup/rollup-freebsd-x64": 4.54.0
+      "@rollup/rollup-linux-arm-gnueabihf": 4.54.0
+      "@rollup/rollup-linux-arm-musleabihf": 4.54.0
+      "@rollup/rollup-linux-arm64-gnu": 4.54.0
+      "@rollup/rollup-linux-arm64-musl": 4.54.0
+      "@rollup/rollup-linux-loong64-gnu": 4.54.0
+      "@rollup/rollup-linux-ppc64-gnu": 4.54.0
+      "@rollup/rollup-linux-riscv64-gnu": 4.54.0
+      "@rollup/rollup-linux-riscv64-musl": 4.54.0
+      "@rollup/rollup-linux-s390x-gnu": 4.54.0
+      "@rollup/rollup-linux-x64-gnu": 4.54.0
+      "@rollup/rollup-linux-x64-musl": 4.54.0
+      "@rollup/rollup-openharmony-arm64": 4.54.0
+      "@rollup/rollup-win32-arm64-msvc": 4.54.0
+      "@rollup/rollup-win32-ia32-msvc": 4.54.0
+      "@rollup/rollup-win32-x64-gnu": 4.54.0
+      "@rollup/rollup-win32-x64-msvc": 4.54.0
       fsevents: 2.3.3
 
   rxjs@7.8.2:
@@ -2572,10 +2922,10 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-mls@1.4.3(@noble/ciphers@2.0.1)(@noble/curves@2.0.1):
+  ts-mls@1.5.0(@noble/ciphers@2.1.1)(@noble/curves@2.0.1):
     dependencies:
       "@hpke/core": 1.7.5
-      "@noble/ciphers": 2.0.1
+      "@noble/ciphers": 2.1.1
     optionalDependencies:
       "@noble/curves": 2.0.1
 
@@ -2632,13 +2982,13 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6):
+  vite-node@3.2.4(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6)
     transitivePeerDependencies:
       - "@types/node"
       - jiti
@@ -2653,25 +3003,25 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6):
+  vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6):
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.53.3
+      rollup: 4.54.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      "@types/node": 24.10.1
+      "@types/node": 24.10.4
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.20.6
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6):
     dependencies:
       "@types/chai": 5.2.3
       "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6))
+      "@vitest/mocker": 3.2.4(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6))
       "@vitest/pretty-format": 3.2.4
       "@vitest/runner": 3.2.4
       "@vitest/snapshot": 3.2.4
@@ -2679,7 +3029,7 @@ snapshots:
       "@vitest/utils": 3.2.4
       chai: 5.3.3
       debug: 4.4.3
-      expect-type: 1.2.2
+      expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
@@ -2689,12 +3039,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)
-      vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(tsx@4.20.6)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6)
+      vite-node: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.20.6)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/debug": 4.1.12
-      "@types/node": 24.10.1
+      "@types/node": 24.10.4
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -80,7 +80,6 @@ describe("exports", () => {
         "normalizeRelayUrl",
         "readGroupMessages",
         "replaceExtension",
-        "replacer",
         "serializeApplicationRumor",
         "serializeClientState",
         "sortGroupCommits",

--- a/src/core/marmot-group-data.ts
+++ b/src/core/marmot-group-data.ts
@@ -151,7 +151,11 @@ export function decodeMarmotGroupData(
   const textDecoder = new TextDecoder();
 
   // Read version (2 bytes, big-endian)
-  const version = new DataView(extensionData.buffer).getUint16(offset, false);
+  const version = new DataView(
+    extensionData.buffer,
+    extensionData.byteOffset + offset,
+    2,
+  ).getUint16(0, false);
   offset += 2;
 
   // Validate version
@@ -304,7 +308,12 @@ function decodeVariableLengthField(
     throw new Error("Buffer too short to read length prefix");
   }
 
-  const length = new DataView(buffer.buffer).getUint16(offset, false);
+  // Create a DataView that accounts for the buffer's byteOffset
+  const length = new DataView(
+    buffer.buffer,
+    buffer.byteOffset + offset,
+    2,
+  ).getUint16(0, false);
   offset += 2;
 
   if (offset + length > buffer.length) {


### PR DESCRIPTION
Replace custom JSON-based serialization with ts-mls binary encoding for ClientState. Update serializeClientState and deserializeClientState to use encodeGroupState/decodeGroupState. Remove replacer/reviver functions and change SerializedClientState type to Uint8Array. Update EncryptedKeyValueStore to handle binary data directly. Add tests for byteOffset handling in marmot group data decoding. Update dependencies and remove deprecated exports.

BREAKING CHANGE: Storage format changed from JSON to binary, existing stored ClientState data is incompatible and will be lost. Clear storage and re-initialize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for converting group data to extension format, enabling improved serialization workflows.

* **Bug Fixes**
  * Fixed binary data offset handling in data view operations.
  * Enhanced error handling with improved logging and recovery.

* **Chores**
  * Updated dependency versions: cryptography libraries, MLS tools, TypeScript types, and code formatting utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->