### PR TITLE
refactor: improve library ergonomics and other issues

### DIFF
--- a/chat/package.json
+++ b/chat/package.json
@@ -13,6 +13,7 @@
     "@base-ui/react": "^1.1.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@libs/qrcode": "jsr:^3.0.1",
+    "@noble/hashes": "^2.0.1",
     "@tabler/icons-react": "^3.36.1",
     "applesauce-accounts": "^5.0.0",
     "applesauce-actions": "^5.0.2",

--- a/chat/src/hooks/use-group-messages.ts
+++ b/chat/src/hooks/use-group-messages.ts
@@ -75,7 +75,7 @@ export function useGroupMessages(
     const listener = (rumor: Rumor) => addNewMessages([rumor]);
     group.history.addListener("rumor", listener);
     return () => {
-      group.history.removeListener("rumor", listener);
+      group?.history?.removeListener("rumor", listener);
     };
   }, [group, addNewMessages]);
 

--- a/chat/src/lib/group-subscription-manager.ts
+++ b/chat/src/lib/group-subscription-manager.ts
@@ -2,7 +2,6 @@ import type { Rumor } from "applesauce-common/helpers/gift-wrap";
 import type { NostrEvent } from "applesauce-core/helpers";
 import {
   deserializeApplicationRumor,
-  getNostrGroupIdHex,
   GROUP_EVENT_KIND,
   MarmotClient,
   MarmotGroup,
@@ -10,6 +9,7 @@ import {
 import { BehaviorSubject, Subscription } from "rxjs";
 
 import { pool } from "@/lib/nostr";
+import { bytesToHex } from "@noble/hashes/utils.js";
 
 /**
  * Manages persistent subscriptions for all groups in the store.
@@ -106,11 +106,11 @@ export class GroupSubscriptionManager {
     if (!this.isActive) return;
 
     try {
-      const groups = await this.client.groupStore.list();
+      const groups = await this.client.groupStateStore.list();
       const groupIds = new Set<string>();
 
-      for (const groupState of groups) {
-        const groupIdHex = getNostrGroupIdHex(groupState);
+      for (const groupId of groups) {
+        const groupIdHex = bytesToHex(groupId);
         groupIds.add(groupIdHex);
 
         if (!this.groupSubscriptions.has(groupIdHex)) {

--- a/chat/src/lib/marmot-client.ts
+++ b/chat/src/lib/marmot-client.ts
@@ -7,14 +7,12 @@ import {
   MarmotGroup,
   NostrNetworkInterface,
   PublishResponse,
+  KeyPackageStore,
 } from "marmot-ts";
 import {
   firstValueFrom,
-  from,
-  fromEvent,
   lastValueFrom,
   map,
-  merge,
   Observable,
   of,
   shareReplay,
@@ -69,13 +67,13 @@ export const marmotClient$ = accounts.active$.pipe(
     if (!account) return;
 
     // Get storage interfaces for the account
-    const { groupStore, keyPackageStore, historyFactory } =
+    const { groupStateBackend, keyPackageStore, historyFactory } =
       await databaseBroker.getStorageInterfacesForAccount(account.pubkey);
 
     // Create a new marmot client for the active account
     return new MarmotClient({
       signer: account.signer,
-      groupStore,
+      groupStateBackend,
       keyPackageStore,
       network: networkInterface,
       historyFactory,
@@ -85,41 +83,70 @@ export const marmotClient$ = accounts.active$.pipe(
   shareReplay(1),
 );
 
-// TODO: this is ugly, MarmotClient or KeyPackageStore should expose a simple interface to subscribe to key package changes
-// Maybe an AsyncGenerator could be used as a simple stream of updates?
+/**
+ * Converts the client's watchKeyPackages async generator to an RxJS Observable.
+ * This provides a reactive stream of key package updates.
+ */
 export const liveKeyPackages$ = marmotClient$.pipe(
   switchMap((client) => {
     if (!client) return of([]);
 
-    return merge(
-      // Start with true to trigger load
-      of(true),
-      // Listen for key package events
-      fromEvent(client.keyPackageStore, "keyPackageAdded"),
-      fromEvent(client.keyPackageStore, "keyPackageRemoved"),
-    ).pipe(
-      switchMap(() =>
-        // Load key packages list
-        from(client.keyPackageStore.list()),
-      ),
+    // Use the new watchKeyPackages async generator from MarmotClient
+    return new Observable<Awaited<ReturnType<KeyPackageStore["list"]>>>(
+      (subscriber) => {
+        const abortController = new AbortController();
+
+        (async () => {
+          try {
+            for await (const keyPackages of client.watchKeyPackages()) {
+              if (abortController.signal.aborted) break;
+              subscriber.next(keyPackages);
+            }
+          } catch (error) {
+            subscriber.error(error);
+          } finally {
+            subscriber.complete();
+          }
+        })();
+
+        return () => {
+          abortController.abort();
+        };
+      },
     );
   }),
   shareReplay(1),
 );
 
-// TODO: this is a little better but still ugly
+/**
+ * Converts the client's watchGroups async generator to an RxJS Observable.
+ * This provides a reactive stream of group updates.
+ */
 export const liveGroups$ = marmotClient$.pipe(
   switchMap((client) => {
     if (!client) return of([]);
 
-    return merge(
-      // Start with true to trigger load
-      from(client.loadAllGroups()),
-      // Listen for group events
-      fromEvent(client, "groupsUpdated") as Observable<
-        MarmotGroup<GroupRumorHistory>[]
-      >,
-    );
+    // Use the new watchGroups async generator from MarmotClient
+    return new Observable<MarmotGroup<GroupRumorHistory>[]>((subscriber) => {
+      const abortController = new AbortController();
+
+      (async () => {
+        try {
+          for await (const groups of client.watchGroups()) {
+            if (abortController.signal.aborted) break;
+            subscriber.next(groups);
+          }
+        } catch (error) {
+          subscriber.error(error);
+        } finally {
+          subscriber.complete();
+        }
+      })();
+
+      return () => {
+        abortController.abort();
+      };
+    });
   }),
   shareReplay(1),
 );

--- a/chat/src/pages/contacts/[npub].tsx
+++ b/chat/src/pages/contacts/[npub].tsx
@@ -7,7 +7,6 @@ import {
 } from "applesauce-core/helpers";
 import { use$ } from "applesauce-react/hooks";
 import {
-  extractMarmotGroupData,
   getCredentialPubkey,
   getKeyPackage,
   getKeyPackageCipherSuiteId,
@@ -397,7 +396,7 @@ function ContactDetailContent({ user }: { user: User }) {
   const groups = use$(
     () =>
       marmotClient$.pipe(
-        switchMap((client) => client?.groupStore.list() ?? of([])),
+        switchMap((client) => client?.groupStateStore.list() ?? of([])),
       ),
     [],
   );
@@ -489,13 +488,11 @@ function ContactDetailContent({ user }: { user: User }) {
                         <SelectValue placeholder="Select a group" />
                       </SelectTrigger>
                       <SelectContent>
-                        {(groups ?? []).map((g) => {
-                          const groupId = bytesToHex(g.groupContext.groupId);
-                          const name =
-                            extractMarmotGroupData(g)?.name || "Unnamed Group";
+                        {(groups ?? []).map((groupId: Uint8Array) => {
+                          const groupIdHex = bytesToHex(groupId);
                           return (
-                            <SelectItem key={groupId} value={groupId}>
-                              {name}
+                            <SelectItem key={groupIdHex} value={groupIdHex}>
+                              {groupIdHex.slice(0, 16)}...
                             </SelectItem>
                           );
                         })}

--- a/chat/src/pages/groups/[id].tsx
+++ b/chat/src/pages/groups/[id].tsx
@@ -329,7 +329,7 @@ function GroupDetailPage() {
       const sentRumor = await sendMessage(text);
 
       // Optimistically save new messages to the groups history for immediate feedback
-      if (sentRumor) await group?.history.saveRumor(sentRumor);
+      if (sentRumor && group?.history) await group.history.saveRumor(sentRumor);
     } catch (err) {
       // Error is already set by useMessageSender
     }

--- a/examples/src/lib/group-subscription-manager.ts
+++ b/examples/src/lib/group-subscription-manager.ts
@@ -1,9 +1,9 @@
 import { Subscription } from "rxjs";
 import { NostrEvent } from "applesauce-core/helpers/event";
+import { bytesToHex } from "@noble/hashes/utils.js";
 import { MarmotClient } from "../../../src";
 import { MarmotGroup } from "../../../src/client/group/marmot-group";
 import { GROUP_EVENT_KIND } from "../../../src";
-import { getNostrGroupIdHex } from "../../../src";
 import { pool } from "./nostr";
 import { deserializeApplicationRumor } from "../../../src";
 import { Rumor } from "applesauce-common/helpers/gift-wrap";
@@ -82,12 +82,12 @@ export class GroupSubscriptionManager {
 
     try {
       // Get all groups from the store
-      const groups = await this.client.groupStore.list();
+      const groups = await this.client.groupStateStore.list();
       const groupIds = new Set<string>();
 
       // Ensure we have subscriptions for all groups
-      for (const groupState of groups) {
-        const groupIdHex = getNostrGroupIdHex(groupState);
+      for (const groupId of groups) {
+        const groupIdHex = bytesToHex(groupId);
         groupIds.add(groupIdHex);
 
         if (!this.groupSubscriptions.has(groupIdHex)) {
@@ -247,7 +247,7 @@ export class GroupSubscriptionManager {
       const relays = group.relays;
       if (!relays || relays.length === 0) return;
 
-      const groupIdHex = getNostrGroupIdHex(group.state);
+      const groupIdHex = bytesToHex(group.state.groupContext.groupId);
 
       // Request existing events from relays
       const filters = {

--- a/examples/src/lib/marmot-client.ts
+++ b/examples/src/lib/marmot-client.ts
@@ -76,7 +76,7 @@ export const marmotClient$ = combineLatest([
     // Create a KeyValueGroupStateBackend wrapping localforage
     const groupStateBackend = new KeyValueGroupStateBackend(
       localforage.createInstance({
-        name: "marmot-group-store",
+        name: `marmot-group-store-${account.pubkey}`,
       }),
     );
 
@@ -121,7 +121,7 @@ marmotClient$.subscribe(async (client) => {
 });
 
 // Reconcile subscriptions when client changes and manager is ready
-// Use withLatestFrom to get the latest marmotClient$ value and filter for ready state
+// Obtain the latest marmotClient$ value and ensure manager is ready before reconciling
 marmotClient$
   .pipe(
     filter((client) => {

--- a/examples/src/lib/marmot-client.ts
+++ b/examples/src/lib/marmot-client.ts
@@ -14,7 +14,6 @@ import {
 } from "rxjs";
 import localforage from "localforage";
 import {
-  GroupStateStore,
   KeyValueGroupStateBackend,
   MarmotClient,
   defaultMarmotClientConfig,
@@ -74,17 +73,16 @@ export const marmotClient$ = combineLatest([
   keyPackageStore$,
 ]).pipe(
   map(([account, keyPackageStore]) => {
-    // Create a GroupStateStore with a KeyValueGroupStateBackend wrapping localforage
+    // Create a KeyValueGroupStateBackend wrapping localforage
     const groupStateBackend = new KeyValueGroupStateBackend(
       localforage.createInstance({
         name: "marmot-group-store",
       }),
     );
-    const groupStateStore = new GroupStateStore(groupStateBackend);
 
     return new MarmotClient({
       signer: account.signer,
-      groupStateBackend: groupStateStore,
+      groupStateBackend,
       keyPackageStore,
       network: networkInterface,
       clientConfig: defaultMarmotClientConfig,

--- a/examples/src/lib/marmot-client.ts
+++ b/examples/src/lib/marmot-client.ts
@@ -2,6 +2,7 @@ import { defined, mapEventsToTimeline, simpleTimeout } from "applesauce-core";
 import { onlyEvents } from "applesauce-relay";
 import {
   combineLatest,
+  filter,
   firstValueFrom,
   from,
   lastValueFrom,
@@ -10,17 +11,21 @@ import {
   shareReplay,
   startWith,
   switchMap,
-  withLatestFrom,
-  filter,
 } from "rxjs";
-import { MarmotClient } from "../../../src";
+import localforage from "localforage";
+import {
+  GroupStateStore,
+  KeyValueGroupStateBackend,
+  MarmotClient,
+  defaultMarmotClientConfig,
+} from "../../../src";
 import { MarmotGroup } from "../../../src/client/group/marmot-group";
 import {
   NostrNetworkInterface,
   PublishResponse,
 } from "../../../src/client/nostr-interface";
 import accounts from "./accounts";
-import { groupStore$, selectedGroupId$ } from "./group-store";
+import { selectedGroupId$ } from "./group-store";
 import { keyPackageStore$ } from "./key-package-store";
 import { eventStore, pool } from "./nostr";
 import { GroupSubscriptionManager } from "./group-subscription-manager";
@@ -66,18 +71,25 @@ export function getSubscriptionManager(): GroupSubscriptionManager | null {
 // Note: We use distinctUntilChanged on the account to avoid recreating the client unnecessarily.
 export const marmotClient$ = combineLatest([
   accounts.active$.pipe(defined()),
-  groupStore$,
   keyPackageStore$,
 ]).pipe(
-  map(
-    ([account, groupStore, keyPackageStore]) =>
-      new MarmotClient({
-        signer: account.signer,
-        groupStore,
-        keyPackageStore,
-        network: networkInterface,
+  map(([account, keyPackageStore]) => {
+    // Create a GroupStateStore with a KeyValueGroupStateBackend wrapping localforage
+    const groupStateBackend = new KeyValueGroupStateBackend(
+      localforage.createInstance({
+        name: "marmot-group-store",
       }),
-  ),
+    );
+    const groupStateStore = new GroupStateStore(groupStateBackend);
+
+    return new MarmotClient({
+      signer: account.signer,
+      groupStateBackend: groupStateStore,
+      keyPackageStore,
+      network: networkInterface,
+      clientConfig: defaultMarmotClientConfig,
+    });
+  }),
   startWith(undefined),
   shareReplay(1),
 );
@@ -110,15 +122,14 @@ marmotClient$.subscribe(async (client) => {
   }
 });
 
-// Reconcile subscriptions when group store changes, but only after manager is ready
+// Reconcile subscriptions when client changes and manager is ready
 // Use withLatestFrom to get the latest marmotClient$ value and filter for ready state
-groupStore$
+marmotClient$
   .pipe(
-    withLatestFrom(marmotClient$),
-    filter(([store, client]) => {
-      // Only proceed if store exists, client exists, and subscription manager is fully initialized
+    filter((client) => {
+      // Only proceed when client exists and subscription manager is fully initialized
       return Boolean(
-        store && client && isSubscriptionManagerReady && subscriptionManager,
+        client && isSubscriptionManagerReady && subscriptionManager,
       );
     }),
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       "@libs/qrcode":
         specifier: jsr:^3.0.1
         version: "@jsr/libs__qrcode@3.0.1"
+      "@noble/hashes":
+        specifier: ^2.0.1
+        version: 2.0.1
       "@tabler/icons-react":
         specifier: ^3.36.1
         version: 3.36.1(react@19.2.4)
@@ -7600,7 +7603,7 @@ snapshots:
   "@scure/bip32@1.3.1":
     dependencies:
       "@noble/curves": 1.1.0
-      "@noble/hashes": 1.3.1
+      "@noble/hashes": 1.3.2
       "@scure/base": 1.1.1
 
   "@scure/bip32@2.0.1":
@@ -7611,7 +7614,7 @@ snapshots:
 
   "@scure/bip39@1.2.1":
     dependencies:
-      "@noble/hashes": 1.3.1
+      "@noble/hashes": 1.3.2
       "@scure/base": 1.1.1
 
   "@sec-ant/readable-stream@0.4.1": {}

--- a/src/__tests__/end-to-end-invite-join-message.test.ts
+++ b/src/__tests__/end-to-end-invite-join-message.test.ts
@@ -24,8 +24,9 @@ import {
   KEY_PACKAGE_KIND,
   WELCOME_EVENT_KIND,
 } from "../core/protocol";
-import { GroupStore } from "../store/group-store";
 import { KeyPackageStore } from "../store/key-package-store";
+import { GroupStateStore } from "../store/group-state-store";
+import { KeyValueGroupStateBackend } from "../store/adapters/key-value-group-state-backend";
 import { unixNow } from "../utils/nostr";
 import { MockNetwork } from "./helpers/mock-network";
 import { MemoryBackend } from "./ingest-commit-race.test";
@@ -58,25 +59,21 @@ describe("End-to-end: invite, join, first message", () => {
     // Create mock network
     mockNetwork = new MockNetwork();
 
-    // Create clients
-    const groupStore = new GroupStore(
+    // Create clients using the new bytes-first API
+    const groupStateBackend = new KeyValueGroupStateBackend(
       new MemoryBackend(),
-      defaultMarmotClientConfig,
     );
     const keyPackageStore = new KeyPackageStore(new MemoryBackend());
 
     adminClient = new MarmotClient({
-      groupStore,
+      groupStateBackend,
       keyPackageStore,
       signer: adminAccount.signer,
       network: mockNetwork,
     });
 
     inviteeClient = new MarmotClient({
-      groupStore: new GroupStore(
-        new MemoryBackend(),
-        defaultMarmotClientConfig,
-      ),
+      groupStateBackend: new KeyValueGroupStateBackend(new MemoryBackend()),
       keyPackageStore: new KeyPackageStore(new MemoryBackend()),
       signer: inviteeAccount.signer,
       network: mockNetwork,

--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -7,6 +7,7 @@ describe("exports", () => {
       [
         "GROUP_EVENT_KIND",
         "GroupRumorHistory",
+        "GroupStateStore",
         "GroupStore",
         "KEY_PACKAGE_CIPHER_SUITE_TAG",
         "KEY_PACKAGE_CLIENT_TAG",
@@ -17,6 +18,7 @@ describe("exports", () => {
         "KEY_PACKAGE_RELAY_LIST_KIND",
         "KEY_PACKAGE_RELAY_LIST_RELAY_TAG",
         "KeyPackageStore",
+        "KeyValueGroupStateBackend",
         "LAST_RESORT_KEY_PACKAGE_EXTENSION_TYPE",
         "MARMOT_GROUP_DATA_EXTENSION_TYPE",
         "MARMOT_GROUP_DATA_VERSION",

--- a/src/client/group/marmot-group.ts
+++ b/src/client/group/marmot-group.ts
@@ -25,7 +25,10 @@ import {
 import { MLSMessage } from "ts-mls/message.js";
 import { getCredentialFromLeafIndex } from "ts-mls/ratchetTree.js";
 import { type LeafIndex, toLeafIndex } from "ts-mls/treemath.js";
-import { extractMarmotGroupData } from "../../core/client-state.js";
+import {
+  extractMarmotGroupData,
+  serializeClientState,
+} from "../../core/client-state.js";
 import { getCredentialPubkey } from "../../core/credential.js";
 import {
   createGroupEvent,
@@ -178,7 +181,7 @@ export class MarmotGroup<
   readonly network: NostrNetworkInterface;
 
   /** The storage interface for the groups application message history */
-  readonly history: THistory | undefined;
+  readonly history: THistory;
 
   /** Whether group state has been modified */
   dirty = false;
@@ -242,7 +245,7 @@ export class MarmotGroup<
         this.history = options.history;
       }
     } else {
-      this.history = undefined;
+      this.history = undefined as THistory;
     }
 
     // Set useful fields
@@ -290,7 +293,6 @@ export class MarmotGroup<
     if (!this.dirty) return;
 
     // Import serializeClientState dynamically to avoid circular dependencies
-    const { serializeClientState } = await import("../../core/client-state.js");
     const stateBytes = serializeClientState(this.state);
     await this.stateStore.set(this.id, stateBytes);
     this.dirty = false;

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -20,12 +20,22 @@ import {
   CiphersuiteName,
   getCiphersuiteFromId,
 } from "ts-mls/crypto/ciphersuite.js";
+import { ClientConfig } from "ts-mls/clientConfig.js";
 import { createCredential } from "../core/credential.js";
 import { defaultCapabilities } from "../core/default-capabilities.js";
 import { createSimpleGroup, SimpleGroupOptions } from "../core/group.js";
 import { generateKeyPackage } from "../core/key-package.js";
 import { getWelcome } from "../core/welcome.js";
-import { GroupStore } from "../store/group-store.js";
+import {
+  deserializeClientState,
+  serializeClientState,
+  SerializedClientState,
+} from "../core/client-state.js";
+import { defaultMarmotClientConfig } from "../core/client-state.js";
+import {
+  GroupStateStore,
+  GroupStateStoreBackend,
+} from "../store/group-state-store.js";
 import { KeyPackageStore } from "../store/key-package-store.js";
 import {
   BaseGroupHistory,
@@ -41,13 +51,15 @@ export type MarmotClientOptions<THistory extends BaseGroupHistory | undefined> =
     /** The capabilities to use for the client */
     capabilities?: Capabilities;
     /** The backend to store and load the groups from */
-    groupStore: GroupStore;
+    groupStateBackend: GroupStateStoreBackend;
     /** The backend to store and load the key packages from */
     keyPackageStore: KeyPackageStore;
     /** The crypto provider to use for cryptographic operations */
     cryptoProvider?: CryptoProvider;
     /** The nostr relay pool to use for the client. Should implement GroupNostrInterface for group operations. */
     network: NostrNetworkInterface;
+    /** The ClientConfig to use for state hydration (contains auth service and policy) */
+    clientConfig?: ClientConfig;
   } & (THistory extends undefined
     ? {}
     : {
@@ -83,12 +95,14 @@ export class MarmotClient<
   readonly signer: EventSigner;
   /** The capabilities to use for the client */
   readonly capabilities: Capabilities;
-  /** The backend to store and load the groups from */
-  readonly groupStore: GroupStore;
+  /** The store for group state (bytes-only) */
+  readonly groupStateStore: GroupStateStore;
   /** The backend to store and load the key packages from */
   readonly keyPackageStore: KeyPackageStore;
   /** The nostr relay pool to use for the client */
   readonly network: NostrNetworkInterface;
+  /** The ClientConfig used for state hydration */
+  readonly clientConfig: ClientConfig;
 
   /** Crypto provider for cryptographic operations */
   public cryptoProvider: CryptoProvider;
@@ -105,10 +119,11 @@ export class MarmotClient<
     super();
     this.signer = options.signer;
     this.capabilities = options.capabilities ?? defaultCapabilities();
-    this.groupStore = options.groupStore;
+    this.groupStateStore = new GroupStateStore(options.groupStateBackend);
     this.keyPackageStore = options.keyPackageStore;
     this.network = options.network;
     this.cryptoProvider = options.cryptoProvider ?? defaultCryptoProvider;
+    this.clientConfig = options.clientConfig ?? defaultMarmotClientConfig;
 
     // Set the history factory if its set in the options
     this.historyFactory = (
@@ -127,8 +142,21 @@ export class MarmotClient<
     return await getCiphersuiteImpl(suite, this.cryptoProvider);
   }
 
+  /** Hydrates a SerializedClientState into a ClientState using this client's config */
+  private hydrateState(serialized: SerializedClientState): ClientState {
+    return deserializeClientState(serialized, this.clientConfig);
+  }
+
+  /** Serializes a ClientState into bytes */
+  private serializeState(state: ClientState): SerializedClientState {
+    return serializeClientState(state);
+  }
+
   /** Internal store for loaded group classes */
   #groups = new Map<string, MarmotGroup<THistory>>();
+
+  /** Tracks in-flight group loads to prevent duplicate instances under concurrency */
+  #groupLoadPromises = new Map<string, Promise<MarmotGroup<THistory>>>();
 
   /** Sets a group instance in the cache */
   private setGroupInstance(group: MarmotGroup<THistory>) {
@@ -148,8 +176,17 @@ export class MarmotClient<
   private async loadGroup(
     groupId: Uint8Array | string,
   ): Promise<MarmotGroup<THistory>> {
-    return await MarmotGroup.load<THistory>(groupId, {
-      store: this.groupStore,
+    const id = typeof groupId === "string" ? hexToBytes(groupId) : groupId;
+    const stateBytes = await this.groupStateStore.get(id);
+
+    if (!stateBytes) {
+      throw new Error(`Group ${bytesToHex(id)} not found`);
+    }
+
+    const state = this.hydrateState(stateBytes);
+
+    return await MarmotGroup.fromClientState<THistory>(state, {
+      stateStore: this.groupStateStore,
       signer: this.signer,
       cryptoProvider: this.cryptoProvider,
       network: this.network,
@@ -163,11 +200,24 @@ export class MarmotClient<
     let group = this.#groups.get(id);
 
     if (!group) {
-      group = await this.loadGroup(groupId);
+      const existingLoad = this.#groupLoadPromises.get(id);
+      if (existingLoad) {
+        group = await existingLoad;
+      } else {
+        const loadPromise = this.loadGroup(groupId)
+          .then((loaded) => {
+            // Save group to cache
+            this.setGroupInstance(loaded);
+            this.emit("groupLoaded", loaded);
+            return loaded;
+          })
+          .finally(() => {
+            this.#groupLoadPromises.delete(id);
+          });
 
-      // Save group to cache
-      this.setGroupInstance(group);
-      this.emit("groupLoaded", group);
+        this.#groupLoadPromises.set(id, loadPromise);
+        group = await loadPromise;
+      }
     }
 
     return group;
@@ -175,10 +225,15 @@ export class MarmotClient<
 
   /** Loads all groups from the store and returns them */
   async loadAllGroups(): Promise<MarmotGroup<THistory>[]> {
-    const states = await this.groupStore.list();
+    const groupIds = await this.groupStateStore.list();
+
+    // De-dupe group IDs defensively in case a backend returns duplicates.
+    const uniqueIds = Array.from(
+      new Map(groupIds.map((gid) => [bytesToHex(gid), gid] as const)).values(),
+    );
 
     return await Promise.all(
-      states.map((state) => this.getGroup(state.groupContext.groupId)),
+      uniqueIds.map((groupId) => this.getGroup(groupId)),
     );
   }
 
@@ -187,21 +242,22 @@ export class MarmotClient<
     state: ClientState,
   ): Promise<MarmotGroup<THistory>> {
     const id = bytesToHex(state.groupContext.groupId);
-    if (await this.groupStore.has(id)) {
+    if (await this.groupStateStore.has(state.groupContext.groupId)) {
       throw new Error(`Group ${id} already exists`);
     }
 
+    // Serialize and store the state
+    const stateBytes = this.serializeState(state);
+    await this.groupStateStore.set(state.groupContext.groupId, stateBytes);
+
     // Create a new MarmotGroup instance from the ClientState
     const group = await MarmotGroup.fromClientState(state, {
-      store: this.groupStore,
+      stateStore: this.groupStateStore,
       signer: this.signer,
       cryptoProvider: this.cryptoProvider,
       network: this.network,
       history: this.historyFactory,
     });
-
-    // Save group to store
-    await this.groupStore.add(state);
 
     // Add group to cache
     this.setGroupInstance(group);
@@ -224,17 +280,17 @@ export class MarmotClient<
     // Get the existing instance or load a new one
     const group = this.#groups.get(id) || (await this.loadGroup(groupId));
 
-    // Use the instance to destroy the group
+    // Use the instance to destroy the group.
+    // NOTE: MarmotGroup.destroy() is the single owner of removing group state from storage.
     await group.destroy();
 
-    // Remove the group from the cache without emitting an event
-    this.groupStore.remove(groupId);
+    const hexId = typeof groupId === "string" ? hexToBytes(groupId) : groupId;
 
     // Remove the group from the cache
     this.#groups.delete(id);
 
     // Emit events
-    this.emit("groupDestroyed", group.id);
+    this.emit("groupDestroyed", hexId);
     this.emit("groupsUpdated", this.groups);
   }
 
@@ -264,12 +320,16 @@ export class MarmotClient<
     );
 
     // Save the group to the store
-    await this.groupStore.add(clientState);
+    const stateBytes = this.serializeState(clientState);
+    await this.groupStateStore.set(
+      clientState.groupContext.groupId,
+      stateBytes,
+    );
 
     // Create and cache the MarmotGroup instance
     const group = new MarmotGroup(clientState, {
       ciphersuite: ciphersuiteImpl,
-      store: this.groupStore,
+      stateStore: this.groupStateStore,
       signer: this.signer,
       network: this.network,
       history: this.historyFactory,
@@ -380,7 +440,7 @@ export class MarmotClient<
     const pskIndex = makePskIndex(undefined, {});
 
     // Try each key package in priority order until one successfully decrypts the Welcome message
-    let clientState: any = null;
+    let clientState: ClientState | null = null;
     let lastError: Error | null = null;
 
     for (const keyPackage of prioritizedKeyPackages) {
@@ -412,12 +472,16 @@ export class MarmotClient<
     }
 
     // Save the group state to the store
-    await this.groupStore.add(clientState);
+    const stateBytes = this.serializeState(clientState);
+    await this.groupStateStore.set(
+      clientState.groupContext.groupId,
+      stateBytes,
+    );
 
     // Create and cache the MarmotGroup instance
     const group = new MarmotGroup(clientState, {
       ciphersuite: ciphersuiteImpl,
-      store: this.groupStore,
+      stateStore: this.groupStateStore,
       signer: this.signer,
       network: this.network,
       history: this.historyFactory,
@@ -428,5 +492,103 @@ export class MarmotClient<
     this.emit("groupJoined", group);
 
     return group;
+  }
+
+  /**
+   * Watches for changes to the groups in the store.
+   * Returns an async generator that yields the current list of groups
+   * whenever the store changes.
+   *
+   * @example
+   * ```ts
+   * for await (const groups of client.watchGroups()) {
+   *   console.log(`Groups updated: ${groups.length} groups`);
+   * }
+   * ```
+   */
+  async *watchGroups(): AsyncGenerator<MarmotGroup<THistory>[]> {
+    // Set up event listeners
+    let resolveNext: (() => void) | null = null;
+
+    const handleChange = () => {
+      if (resolveNext) {
+        resolveNext();
+        resolveNext = null;
+      }
+    };
+
+    this.groupStateStore.on("groupStateAdded", handleChange);
+    this.groupStateStore.on("groupStateUpdated", handleChange);
+    this.groupStateStore.on("groupStateRemoved", handleChange);
+
+    try {
+      // Yield initial state after listeners are installed to avoid missing updates
+      // that occur between snapshot and subscription.
+      yield await this.loadAllGroups();
+
+      while (true) {
+        // Wait for next change
+        await new Promise<void>((resolve) => {
+          resolveNext = resolve;
+        });
+
+        // Yield updated groups
+        yield await this.loadAllGroups();
+      }
+    } finally {
+      // Cleanup
+      this.groupStateStore.off("groupStateAdded", handleChange);
+      this.groupStateStore.off("groupStateUpdated", handleChange);
+      this.groupStateStore.off("groupStateRemoved", handleChange);
+    }
+  }
+
+  /**
+   * Watches for key package changes.
+   * Returns an async generator that yields the current list of key packages
+   * whenever the store changes.
+   *
+   * @example
+   * ```ts
+   * for await (const keyPackages of client.watchKeyPackages()) {
+   *   console.log(`Key packages updated: ${keyPackages.length} packages`);
+   * }
+   * ```
+   */
+  async *watchKeyPackages(): AsyncGenerator<
+    Awaited<ReturnType<KeyPackageStore["list"]>>
+  > {
+    // Set up event listeners
+    let resolveNext: (() => void) | null = null;
+
+    const handleChange = () => {
+      if (resolveNext) {
+        resolveNext();
+        resolveNext = null;
+      }
+    };
+
+    this.keyPackageStore.on("keyPackageAdded", handleChange);
+    this.keyPackageStore.on("keyPackageRemoved", handleChange);
+
+    try {
+      // Yield initial state after listeners are installed to avoid missing updates
+      // that occur between snapshot and subscription.
+      yield await this.keyPackageStore.list();
+
+      while (true) {
+        // Wait for next change
+        await new Promise<void>((resolve) => {
+          resolveNext = resolve;
+        });
+
+        // Yield updated key packages
+        yield await this.keyPackageStore.list();
+      }
+    } finally {
+      // Cleanup
+      this.keyPackageStore.off("keyPackageAdded", handleChange);
+      this.keyPackageStore.off("keyPackageRemoved", handleChange);
+    }
   }
 }

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -44,28 +44,29 @@ import {
 } from "./group/marmot-group.js";
 import { NostrNetworkInterface } from "./nostr-interface.js";
 
-export type MarmotClientOptions<THistory extends BaseGroupHistory | undefined> =
-  {
-    /** The signer used for the clients identity */
-    signer: EventSigner;
-    /** The capabilities to use for the client */
-    capabilities?: Capabilities;
-    /** The backend to store and load the groups from */
-    groupStateBackend: GroupStateStoreBackend;
-    /** The backend to store and load the key packages from */
-    keyPackageStore: KeyPackageStore;
-    /** The crypto provider to use for cryptographic operations */
-    cryptoProvider?: CryptoProvider;
-    /** The nostr relay pool to use for the client. Should implement GroupNostrInterface for group operations. */
-    network: NostrNetworkInterface;
-    /** The ClientConfig to use for state hydration (contains auth service and policy) */
-    clientConfig?: ClientConfig;
-  } & (THistory extends undefined
-    ? {}
-    : {
-        /** The group history interface to be passed to group instaces */
-        historyFactory: GroupHistoryFactory<THistory>;
-      });
+export type MarmotClientOptions<
+  THistory extends BaseGroupHistory | undefined = undefined,
+> = {
+  /** The signer used for the clients identity */
+  signer: EventSigner;
+  /** The capabilities to use for the client */
+  capabilities?: Capabilities;
+  /** The backend to store and load the groups from */
+  groupStateBackend: GroupStateStoreBackend;
+  /** The backend to store and load the key packages from */
+  keyPackageStore: KeyPackageStore;
+  /** The crypto provider to use for cryptographic operations */
+  cryptoProvider?: CryptoProvider;
+  /** The nostr relay pool to use for the client. Should implement GroupNostrInterface for group operations. */
+  network: NostrNetworkInterface;
+  /** The ClientConfig to use for state hydration (contains auth service and policy) */
+  clientConfig?: ClientConfig;
+} & (THistory extends undefined
+  ? {}
+  : {
+      /** The group history interface to be passed to group instaces */
+      historyFactory: GroupHistoryFactory<THistory>;
+    });
 
 /** Given a MarmotClient type, returns the MarmotGroup class type with the same THistory. */
 export type InferGroupType<TClient extends MarmotClient<any>> =
@@ -227,14 +228,7 @@ export class MarmotClient<
   async loadAllGroups(): Promise<MarmotGroup<THistory>[]> {
     const groupIds = await this.groupStateStore.list();
 
-    // De-dupe group IDs defensively in case a backend returns duplicates.
-    const uniqueIds = Array.from(
-      new Map(groupIds.map((gid) => [bytesToHex(gid), gid] as const)).values(),
-    );
-
-    return await Promise.all(
-      uniqueIds.map((groupId) => this.getGroup(groupId)),
-    );
+    return await Promise.all(groupIds.map((groupId) => this.getGroup(groupId)));
   }
 
   /** Imports a new group from a ClientState object */

--- a/src/store/adapters/key-value-group-state-backend.ts
+++ b/src/store/adapters/key-value-group-state-backend.ts
@@ -1,0 +1,35 @@
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+import { SerializedClientState } from "../../core/client-state.js";
+import { KeyValueStoreBackend } from "../../utils/key-value.js";
+import { GroupStateStoreBackend } from "../group-state-store.js";
+
+/**
+ * Adapter to convert a KeyValueStoreBackend<string, SerializedClientState> to GroupStateStoreBackend.
+ * This is useful for migrating existing backends that use string keys.
+ */
+export class KeyValueGroupStateBackend implements GroupStateStoreBackend {
+  constructor(private backend: KeyValueStoreBackend<SerializedClientState>) {}
+
+  async get(groupId: Uint8Array): Promise<SerializedClientState | null> {
+    const key = bytesToHex(groupId);
+    return this.backend.getItem(key);
+  }
+
+  async set(
+    groupId: Uint8Array,
+    stateBytes: SerializedClientState,
+  ): Promise<void> {
+    const key = bytesToHex(groupId);
+    await this.backend.setItem(key, stateBytes);
+  }
+
+  async remove(groupId: Uint8Array): Promise<void> {
+    const key = bytesToHex(groupId);
+    await this.backend.removeItem(key);
+  }
+
+  async list(): Promise<Uint8Array[]> {
+    const keys = await this.backend.keys();
+    return keys.map((key) => hexToBytes(key));
+  }
+}

--- a/src/store/group-state-store.ts
+++ b/src/store/group-state-store.ts
@@ -1,0 +1,107 @@
+import { EventEmitter } from "eventemitter3";
+import { SerializedClientState } from "../core/client-state.js";
+
+/** A generic interface for a bytes-only group state store backend */
+export interface GroupStateStoreBackend {
+  /** Get state bytes from the store by group ID */
+  get(groupId: Uint8Array): Promise<SerializedClientState | null>;
+  /** Set state bytes in the store by group ID */
+  set(groupId: Uint8Array, stateBytes: SerializedClientState): Promise<void>;
+  /** Remove state bytes from the store by group ID */
+  remove(groupId: Uint8Array): Promise<void>;
+  /** List all group IDs in the store */
+  list(): Promise<Uint8Array[]>;
+}
+
+/** Events emitted by the GroupStateStore */
+type GroupStateStoreEvents = {
+  /** Emitted when a group state is added */
+  groupStateAdded: (
+    groupId: Uint8Array,
+    stateBytes: SerializedClientState,
+  ) => void;
+  /** Emitted when a group state is updated */
+  groupStateUpdated: (
+    groupId: Uint8Array,
+    stateBytes: SerializedClientState,
+  ) => void;
+  /** Emitted when a group state is removed */
+  groupStateRemoved: (groupId: Uint8Array) => void;
+};
+
+/**
+ * A bytes-only store for MLS group state.
+ *
+ * This class manages the persistence of MLS group state as raw bytes.
+ * It does NOT handle serialization/deserialization - that is the responsibility
+ * of the MarmotClient which owns the ClientConfig needed for hydration.
+ *
+ * This design ensures:
+ * 1. Storage layer has no dependency on ClientConfig (policy concern)
+ * 2. Storage is backend-neutral and portable
+ * 3. Namespacing is handled by the backend instance, not the store
+ */
+export class GroupStateStore extends EventEmitter<GroupStateStoreEvents> {
+  constructor(private backend: GroupStateStoreBackend) {
+    super();
+  }
+
+  /**
+   * Retrieves the serialized state bytes from storage.
+   *
+   * @param groupId - The group ID
+   * @returns A promise that resolves to the serialized state bytes, or null if not found
+   */
+  async get(groupId: Uint8Array): Promise<SerializedClientState | null> {
+    return this.backend.get(groupId);
+  }
+
+  /**
+   * Stores serialized state bytes.
+   *
+   * This is effectively an upsert: if a group with the same ID already
+   * exists, it will be overwritten; otherwise, it will be created.
+   *
+   * @param groupId - The group ID
+   * @param stateBytes - The serialized state bytes to store
+   */
+  async set(
+    groupId: Uint8Array,
+    stateBytes: SerializedClientState,
+  ): Promise<void> {
+    const exists = await this.backend.get(groupId);
+    await this.backend.set(groupId, stateBytes);
+
+    if (exists) {
+      this.emit("groupStateUpdated", groupId, stateBytes);
+    } else {
+      this.emit("groupStateAdded", groupId, stateBytes);
+    }
+  }
+
+  /**
+   * Removes a group from the store.
+   * @param groupId - The group ID
+   */
+  async remove(groupId: Uint8Array): Promise<void> {
+    await this.backend.remove(groupId);
+    this.emit("groupStateRemoved", groupId);
+  }
+
+  /**
+   * Lists all stored group IDs.
+   * @returns An array of group IDs
+   */
+  async list(): Promise<Uint8Array[]> {
+    return this.backend.list();
+  }
+
+  /**
+   * Checks if a group exists in the store.
+   * @param groupId - The group ID
+   */
+  async has(groupId: Uint8Array): Promise<boolean> {
+    const item = await this.backend.get(groupId);
+    return item !== null;
+  }
+}

--- a/src/store/group-state-store.ts
+++ b/src/store/group-state-store.ts
@@ -10,7 +10,7 @@ export interface GroupStateStoreBackend {
   /** Remove state bytes from the store by group ID */
   remove(groupId: Uint8Array): Promise<void>;
   /** List all group IDs in the store */
-  list(): Promise<Uint8Array[]>;
+  list(): Promise<SerializedClientState[]>;
 }
 
 /** Events emitted by the GroupStateStore */

--- a/src/store/group-state-store.ts
+++ b/src/store/group-state-store.ts
@@ -10,7 +10,7 @@ export interface GroupStateStoreBackend {
   /** Remove state bytes from the store by group ID */
   remove(groupId: Uint8Array): Promise<void>;
   /** List all group IDs in the store */
-  list(): Promise<SerializedClientState[]>;
+  list(): Promise<Uint8Array[]>;
 }
 
 /** Events emitted by the GroupStateStore */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,9 @@
+// New bytes-first storage
+export * from "./group-state-store.js";
+
+// Adapters for common backend patterns
+export * from "./adapters/key-value-group-state-backend.js";
+
+// Legacy hydrated storage (deprecated, will be removed in a future version)
 export * from "./group-store.js";
 export * from "./key-package-store.js";


### PR DESCRIPTION
Current work:
feat(store): implement bytes-first storage with clean separation of concerns

- Create GroupStateStoreBackend interface for bytes-only storage
- MarmotClient now owns ClientConfig and handles hydration
- Move KeyValueGroupStateBackend adapter to src/store/adapters
- Make history optional in MarmotGroupOptions

Fixes:
- Prevent duplicate group instances in loadAllGroups() with promise-lock
- Fix watcher missed-update window by installing listeners before yield
- Clarify single-owner deletion pattern (destroyGroup -> destroy)
- Remove Buffer usage for browser compatibility

BREAKING CHANGE: GroupStore deprecated, use MarmotClient with bytes-first storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live observables for groups and key packages; client state hydration/serialization and improved group lifecycle/watch.
  * New bytes-first group state store and key-value backend adapter for persistent group state, with migration-friendly APIs and exported adapters.

* **Bug Fixes**
  * Safer listener cleanup and guarded message persistence to avoid errors when history is unavailable.

* **Chores**
  * Added a cryptographic/hash utility dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->