### PR TITLE
Fix welcome message not being wrapped in MLSMessage

### DIFF
--- a/.changeset/goofy-islands-clap.md
+++ b/.changeset/goofy-islands-clap.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmots": patch
+---
+
+Fix welcome event content missing outer MLSMessage object

--- a/src/core/welcome.ts
+++ b/src/core/welcome.ts
@@ -97,17 +97,16 @@ export function getWelcome(event: NostrEvent | Rumor): Welcome {
     );
   }
   const encodingFormat = getEncodingTag(event);
-  if (encodingFormat !== "base64") {
+  if (encodingFormat !== "base64")
     throw new Error("Invalid welcome event: missing encoding=base64 tag");
-  }
+
   const content = decodeContent(event.content, encodingFormat);
   const mlsMessage = decode(mlsMessageDecoder, content);
   if (!mlsMessage) throw new Error("Failed to decode welcome message");
-  if (mlsMessage.wireformat !== wireformats.mls_welcome) {
+  if (mlsMessage.wireformat !== wireformats.mls_welcome)
     throw new Error(
       `Expected MLSMessage with mls_welcome wireformat, got wireformat ${mlsMessage.wireformat}`,
     );
-  }
 
-  return (mlsMessage as MlsWelcomeMessage).welcome;
+  return mlsMessage.welcome;
 }

--- a/src/core/welcome.ts
+++ b/src/core/welcome.ts
@@ -1,12 +1,13 @@
 import { Rumor } from "applesauce-common/helpers/gift-wrap";
 import { getTagValue, NostrEvent } from "applesauce-core/helpers/event";
 import { getEventHash } from "nostr-tools";
-import { decode, encode } from "ts-mls";
+import { decode, encode, protocolVersions, wireformats } from "ts-mls";
 import {
-  welcomeDecoder,
-  welcomeEncoder,
-  type Welcome,
-} from "ts-mls/welcome.js";
+  mlsMessageDecoder,
+  mlsMessageEncoder,
+  type MlsWelcomeMessage,
+} from "ts-mls/message.js";
+import { type Welcome } from "ts-mls/welcome.js";
 import {
   decodeContent,
   encodeContent,
@@ -36,8 +37,13 @@ export function createWelcomeRumor({
   keyPackageEvent?: NostrEvent;
   groupRelays: string[];
 }): Rumor {
-  // Serialize the welcome message according to RFC 9420
-  const serializedWelcome = encode(welcomeEncoder, welcome);
+  // Serialize the welcome message as a full MLSMessage (RFC 9420)
+  const mlsMessage: MlsWelcomeMessage = {
+    version: protocolVersions.mls10,
+    wireformat: wireformats.mls_welcome,
+    welcome,
+  };
+  const serializedWelcome = encode(mlsMessageEncoder, mlsMessage);
   const content = encodeContent(serializedWelcome, "base64");
 
   const draft = {
@@ -95,8 +101,13 @@ export function getWelcome(event: NostrEvent | Rumor): Welcome {
     throw new Error("Invalid welcome event: missing encoding=base64 tag");
   }
   const content = decodeContent(event.content, encodingFormat);
-  const welcome = decode(welcomeDecoder, content);
-  if (!welcome) throw new Error("Failed to decode welcome message");
+  const mlsMessage = decode(mlsMessageDecoder, content);
+  if (!mlsMessage) throw new Error("Failed to decode welcome message");
+  if (mlsMessage.wireformat !== wireformats.mls_welcome) {
+    throw new Error(
+      `Expected MLSMessage with mls_welcome wireformat, got wireformat ${mlsMessage.wireformat}`,
+    );
+  }
 
-  return welcome;
+  return (mlsMessage as MlsWelcomeMessage).welcome;
 }

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -21,13 +21,7 @@ export function encodeContent(
   format: EncodingFormat,
 ): string {
   if (format === "base64") {
-    // Convert Uint8Array to base64
-    let binary = "";
-    const len = bytes.byteLength;
-    for (let i = 0; i < len; i++) {
-      binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
+    return btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(""));
   } else {
     // hex format
     return bytesToHex(bytes);
@@ -50,12 +44,7 @@ export function decodeContent(
 
   if (actualFormat === "base64") {
     try {
-      const binaryString = atob(content);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-      return bytes;
+      return Uint8Array.from(atob(content), (c) => c.charCodeAt(0));
     } catch (error) {
       throw new Error(
         `Failed to decode base64 content: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
The welcome message should be wrapped in a MLSMessage object per MIP-02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Welcome events now include the complete message content so recipients reliably receive all required data.

* **Refactor**
  * Internal encoding/decoding streamlined for simpler, more efficient binary/base64 handling, improving reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->