### PR TITLE
fix: prevent automatic self-update in joinGroupFromWelcome to avoid m…

### DIFF
--- a/.changeset/large-colts-decide.md
+++ b/.changeset/large-colts-decide.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmots": patch
+---
+
+Fix joinGroupFromWelcome() to not automatically send a self-update commit, which was causing the joining member to fork if there are pending commits

--- a/src/__tests__/end-to-end-invite-join-message.test.ts
+++ b/src/__tests__/end-to-end-invite-join-message.test.ts
@@ -166,11 +166,10 @@ describe("End-to-end: invite, join, first message", () => {
       keyPackageEventId,
     });
 
-    // MIP-02: joiners SHOULD self-update immediately after Welcome.
-    // This advances the epoch by 1 compared to the admin state immediately
-    // after the invite commit.
+    // Invitee joins at the same epoch as admin (no automatic self-update).
+    // MIP-02 self-update is the caller's responsibility.
     expect(inviteeGroup.state.groupContext.epoch).toBe(
-      adminGroup.state.groupContext.epoch + 1n,
+      adminGroup.state.groupContext.epoch,
     );
 
     // MIP-00: last_resort key packages may be reused to handle race windows.
@@ -191,14 +190,8 @@ describe("End-to-end: invite, join, first message", () => {
       "#h": [nostrGroupIdHex],
     });
 
-    // Admin must ingest the joiner's post-join self-update commit to catch up.
-    for await (const _ of adminGroup.ingest(groupEvents)) {
-      // Drain iterator
-    }
-
-    // NOTE: joining from Welcome yields a state that already includes the
-    // invite commit and then performs a post-join self-update. Ingesting the
-    // backlog should be a no-op (but must not regress state or throw).
+    // Invitee ingests the group backlog (the invite commit). This should be a
+    // no-op since joining from Welcome already incorporates that commit.
     const inviteeEpochBeforeCatchup = inviteeGroup.state.groupContext.epoch;
     for await (const _ of inviteeGroup.ingest(groupEvents)) {
       // Drain iterator
@@ -207,7 +200,7 @@ describe("End-to-end: invite, join, first message", () => {
       inviteeEpochBeforeCatchup,
     );
 
-    // Verify both clients are at the same epoch
+    // Both clients are already at the same epoch — no self-update was sent.
     expect(inviteeGroup.state.groupContext.epoch).toBe(
       adminGroup.state.groupContext.epoch,
     );

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -533,20 +533,10 @@ export class MarmotClient<
       this.emit("keyPackageRelayDeleteRequested", { keyPackageEventId });
     }
 
-    // MIP-02 SHOULD: post-join self-update to rotate leaf key material for forward secrecy.
-    // This is REQUIRED within 24 hours (MIP-02), and recommended immediately.
-    try {
-      await group.selfUpdate();
-      console.log(
-        `[MarmotClient.joinGroupFromWelcome] Post-join self-update commit sent`,
-      );
-    } catch (err) {
-      // Best-effort — failure to self-update is non-fatal.
-      console.warn(
-        `[MarmotClient.joinGroupFromWelcome] Post-join self-update failed:`,
-        err,
-      );
-    }
+    // MIP-02 SHOULD: callers are responsible for calling group.selfUpdate() after
+    // joining to rotate leaf key material for forward secrecy. Doing it automatically
+    // here caused the joining member to fork off to a new epoch before other members
+    // could ingest the commit.
 
     return group;
   }


### PR DESCRIPTION
If a self-update is created before syncing the group messages its almost guaranteed that the new user will fork off the group because they are missing new commit messages