### PR TITLE
Update MIP-03 group message encryption with legacy fallback

### DIFF
--- a/.changeset/khaki-dodos-walk.md
+++ b/.changeset/khaki-dodos-walk.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmots": minor
+---
+
+Update kind 445 group message encryption to the new MIP-03 format and keep legacy decryption fallback with a deprecation warning

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
+    "@scure/base": "^2.0.0",
     "applesauce-common": "^5.1.0",
     "applesauce-core": "^5.1.0",
     "debug": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       "@noble/hashes":
         specifier: ^2.0.1
         version: 2.0.1
+      "@scure/base":
+        specifier: ^2.0.0
+        version: 2.0.0
       applesauce-common:
         specifier: ^5.1.0
         version: 5.1.0(typescript@5.9.3)

--- a/src/__tests__/group-message-encryption.test.ts
+++ b/src/__tests__/group-message-encryption.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createApplicationMessage,
+  defaultCryptoProvider,
+  encode,
+  getCiphersuiteImpl,
+  unsafeTestingAuthenticationService,
+} from "ts-mls";
+import { mlsMessageEncoder } from "ts-mls/message.js";
+
+import {
+  createEncryptedGroupEventContent,
+  decryptGroupMessageEvent,
+} from "../core/group-message.js";
+import { createLegacyEncryptedGroupEventContent } from "../core/group-message-legacy.js";
+import { createCredential } from "../core/credential.js";
+import { createSimpleGroup } from "../core/group.js";
+import { generateKeyPackage } from "../core/key-package.js";
+
+async function createTestState(pubkey: string) {
+  const ciphersuite = await getCiphersuiteImpl(
+    "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+    defaultCryptoProvider,
+  );
+
+  const credential = createCredential(pubkey);
+  const keyPackage = await generateKeyPackage({
+    credential,
+    ciphersuiteImpl: ciphersuite,
+  });
+
+  const { clientState } = await createSimpleGroup(
+    keyPackage,
+    ciphersuite,
+    "Test Group",
+    { adminPubkeys: [pubkey], relays: [] },
+  );
+
+  return { clientState, ciphersuite };
+}
+
+describe("group message encryption (MIP-03)", () => {
+  it("encrypts and decrypts with MIP-03 ChaCha20-Poly1305 envelope", async () => {
+    const { clientState, ciphersuite } = await createTestState("a".repeat(64));
+
+    const { message } = await createApplicationMessage({
+      context: {
+        cipherSuite: ciphersuite,
+        authService: unsafeTestingAuthenticationService,
+      },
+      state: clientState,
+      message: new TextEncoder().encode("hello"),
+    });
+
+    const content = await createEncryptedGroupEventContent({
+      state: clientState,
+      ciphersuite,
+      message,
+    });
+
+    const payload = Uint8Array.from(atob(content), (ch) => ch.charCodeAt(0));
+    expect(payload.length).toBeGreaterThan(12);
+
+    const event = {
+      id: "e".repeat(64),
+      kind: 445,
+      pubkey: "f".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "00".repeat(32)]],
+      content,
+      sig: "1".repeat(128),
+    };
+
+    const decoded = await decryptGroupMessageEvent(
+      event,
+      clientState,
+      ciphersuite,
+    );
+
+    expect(encode(mlsMessageEncoder, decoded)).toEqual(
+      encode(mlsMessageEncoder, message),
+    );
+  });
+
+  it("decrypts legacy format via fallback and warns once", async () => {
+    const { clientState, ciphersuite } = await createTestState("b".repeat(64));
+
+    const { message } = await createApplicationMessage({
+      context: {
+        cipherSuite: ciphersuite,
+        authService: unsafeTestingAuthenticationService,
+      },
+      state: clientState,
+      message: new TextEncoder().encode("legacy"),
+    });
+
+    const serialized = encode(mlsMessageEncoder, message);
+    const legacyContent = await createLegacyEncryptedGroupEventContent({
+      state: clientState,
+      ciphersuite,
+      serializedMessage: serialized,
+    });
+
+    const event = {
+      id: "d".repeat(64),
+      kind: 445,
+      pubkey: "c".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "11".repeat(32)]],
+      content: legacyContent,
+      sig: "2".repeat(128),
+    };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await decryptGroupMessageEvent(event, clientState, ciphersuite);
+    await decryptGroupMessageEvent(event, clientState, ciphersuite);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("legacy MIP-03 group message");
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/__tests__/group-message-encryption.test.ts
+++ b/src/__tests__/group-message-encryption.test.ts
@@ -121,4 +121,101 @@ describe("group message encryption (MIP-03)", () => {
 
     warnSpy.mockRestore();
   });
+
+  it("rejects invalid base64 group-event content", async () => {
+    const { clientState, ciphersuite } = await createTestState("c".repeat(64));
+
+    const event = {
+      id: "a".repeat(64),
+      kind: 445,
+      pubkey: "b".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "22".repeat(32)]],
+      content: "###not-base64###",
+      sig: "3".repeat(128),
+    };
+
+    await expect(
+      decryptGroupMessageEvent(event, clientState, ciphersuite),
+    ).rejects.toThrow("Failed to decrypt group message");
+  });
+
+  it("rejects payloads shorter than 12-byte nonce", async () => {
+    const { clientState, ciphersuite } = await createTestState("d".repeat(64));
+
+    const shortPayload = new Uint8Array(11);
+    const content = btoa(String.fromCharCode(...shortPayload));
+
+    const event = {
+      id: "9".repeat(64),
+      kind: 445,
+      pubkey: "8".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "33".repeat(32)]],
+      content,
+      sig: "4".repeat(128),
+    };
+
+    await expect(
+      decryptGroupMessageEvent(event, clientState, ciphersuite),
+    ).rejects.toThrow("Failed to decrypt group message");
+  });
+
+  it("rejects tampered ciphertext/auth tag", async () => {
+    const { clientState, ciphersuite } = await createTestState("e".repeat(64));
+
+    const { message } = await createApplicationMessage({
+      context: {
+        cipherSuite: ciphersuite,
+        authService: unsafeTestingAuthenticationService,
+      },
+      state: clientState,
+      message: new TextEncoder().encode("tamper-check"),
+    });
+
+    const content = await createEncryptedGroupEventContent({
+      state: clientState,
+      ciphersuite,
+      message,
+    });
+
+    const payload = Uint8Array.from(atob(content), (ch) => ch.charCodeAt(0));
+    payload[payload.length - 1] ^= 0x01;
+    const tamperedContent = btoa(String.fromCharCode(...payload));
+
+    const event = {
+      id: "7".repeat(64),
+      kind: 445,
+      pubkey: "6".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "44".repeat(32)]],
+      content: tamperedContent,
+      sig: "5".repeat(128),
+    };
+
+    await expect(
+      decryptGroupMessageEvent(event, clientState, ciphersuite),
+    ).rejects.toThrow("Failed to decrypt group message");
+  });
+
+  it("rejects payload with 12-byte nonce and empty ciphertext", async () => {
+    const { clientState, ciphersuite } = await createTestState("f".repeat(64));
+
+    const nonceOnly = new Uint8Array(12);
+    const content = btoa(String.fromCharCode(...nonceOnly));
+
+    const event = {
+      id: "5".repeat(64),
+      kind: 445,
+      pubkey: "4".repeat(64),
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["h", "55".repeat(32)]],
+      content,
+      sig: "6".repeat(128),
+    };
+
+    await expect(
+      decryptGroupMessageEvent(event, clientState, ciphersuite),
+    ).rejects.toThrow("Failed to decrypt group message");
+  });
 });

--- a/src/client/group/marmot-group.ts
+++ b/src/client/group/marmot-group.ts
@@ -13,6 +13,7 @@ import {
   CreateCommitOptions,
   createProposal,
   CryptoProvider,
+  defaultProposalTypes,
   defaultCryptoProvider,
   MlsMessage,
   processMessage,
@@ -178,11 +179,7 @@ export function createAdminCommitPolicyCallback(args: {
   return (incoming) => {
     if (incoming.kind === "proposal") return "accept";
 
-    // MIP-02: post-join self-updates are expressed as commits with no proposals.
-    // These MUST be accepted from any member (admin or not) to allow key hygiene.
-    if (incoming.proposals.length === 0) return "accept";
-
-    // Commit must be attributable to an admin.
+    // Commit must be attributable to a concrete member leaf.
     const senderLeafIndexUnknown = incoming.senderLeafIndex;
     if (senderLeafIndexUnknown === undefined) return "reject";
 
@@ -197,7 +194,23 @@ export function createAdminCommitPolicyCallback(args: {
         senderLeafIndex,
       );
       const senderPubkey = getCredentialPubkey(senderCredential);
-      return adminPubkeys.includes(senderPubkey) ? "accept" : "reject";
+
+      // Admins may commit any proposal set.
+      if (adminPubkeys.includes(senderPubkey)) return "accept";
+
+      // Non-admin compatibility path:
+      // - accept no-proposal commits (current ts-mls self-update shape), OR
+      // - accept commits whose proposals are ONLY update proposals authored by sender.
+      if (incoming.proposals.length === 0) return "accept";
+
+      const isSelfUpdateOnly = incoming.proposals.every(
+        (p) =>
+          p.proposal.proposalType === defaultProposalTypes.update &&
+          p.senderLeafIndex !== undefined &&
+          Number(p.senderLeafIndex) === Number(senderLeafIndex),
+      );
+
+      return isSelfUpdateOnly ? "accept" : "reject";
     } catch {
       // "retry" here means we don't want to permanently reject the commit;
       // MarmotGroup.ingest() will treat processing errors as unreadable/retryable.

--- a/src/core/group-message-legacy.ts
+++ b/src/core/group-message-legacy.ts
@@ -1,0 +1,85 @@
+import { getPublicKey } from "nostr-tools";
+import { decode } from "ts-mls";
+import { ClientState } from "ts-mls/clientState.js";
+import { CiphersuiteImpl } from "ts-mls/crypto/ciphersuite.js";
+import { mlsExporter } from "ts-mls/keySchedule.js";
+import { mlsMessageDecoder, type MlsMessage } from "ts-mls/message.js";
+import {
+  decryptBytes,
+  encryptBytes,
+  getConversationKey,
+} from "../utils/nip44-binary.js";
+
+let hasWarnedLegacyGroupMessage = false;
+
+/**
+ * Emits a one-time warning when legacy MIP-03 group-message decryption is used.
+ */
+export function warnLegacyGroupMessageUsed(): void {
+  if (hasWarnedLegacyGroupMessage) return;
+
+  hasWarnedLegacyGroupMessage = true;
+  console.warn(
+    "[marmot-ts] Decoded legacy MIP-03 group message format (NIP-44 envelope). This compatibility path is deprecated and will be removed in a future release.",
+  );
+}
+
+/**
+ * Legacy key derivation for pre-spec-update kind-445 payloads.
+ *
+ * Old format used MLS-Exporter("nostr", "nostr", 32) and then derived a
+ * self-addressed NIP-44 conversation key from that secret.
+ */
+async function getLegacyGroupConversationKey(
+  clientState: ClientState,
+  ciphersuite: CiphersuiteImpl,
+): Promise<Uint8Array> {
+  const nostrSecret = await mlsExporter(
+    clientState.keySchedule.exporterSecret,
+    "nostr",
+    new TextEncoder().encode("nostr"),
+    32,
+    ciphersuite,
+  );
+  const publicKey = getPublicKey(nostrSecret);
+  return getConversationKey(nostrSecret, publicKey);
+}
+
+/**
+ * Decrypts the legacy kind-445 content envelope and decodes an MLSMessage.
+ *
+ * This compatibility path exists only for historical events and should be
+ * removed after ecosystem migration to the current MIP-03 format.
+ */
+export async function decryptLegacyGroupMessageEventContent(
+  content: string,
+  clientState: ClientState,
+  ciphersuite: CiphersuiteImpl,
+): Promise<MlsMessage> {
+  const conversationKey = await getLegacyGroupConversationKey(
+    clientState,
+    ciphersuite,
+  );
+  const serializedMessage = decryptBytes(content, conversationKey);
+
+  const decoded = decode(mlsMessageDecoder, serializedMessage);
+  if (!decoded) throw new Error("Failed to decode legacy MLS message");
+
+  warnLegacyGroupMessageUsed();
+  return decoded;
+}
+
+/**
+ * Legacy content encoder kept for test coverage and migration tooling only.
+ */
+export async function createLegacyEncryptedGroupEventContent(options: {
+  state: ClientState;
+  ciphersuite: CiphersuiteImpl;
+  serializedMessage: Uint8Array;
+}): Promise<string> {
+  const conversationKey = await getLegacyGroupConversationKey(
+    options.state,
+    options.ciphersuite,
+  );
+  return encryptBytes(options.serializedMessage, conversationKey);
+}

--- a/src/core/group-message.ts
+++ b/src/core/group-message.ts
@@ -54,9 +54,9 @@ export async function decryptGroupMessageEvent(
   try {
     const key = await getGroupEventEncryptionKey(clientState, ciphersuite);
     const payload = decodeBase64(message.content);
-    if (payload.length < 12) {
+    if (payload.length < 28) {
       throw new Error(
-        "Malformed group event content: expected at least 12 bytes",
+        "Malformed group event content: expected at least 28 bytes",
       );
     }
 

--- a/src/core/group-message.ts
+++ b/src/core/group-message.ts
@@ -1,10 +1,7 @@
 import { Rumor } from "applesauce-common/helpers/gift-wrap";
-import {
-  finalizeEvent,
-  generateSecretKey,
-  getPublicKey,
-  NostrEvent,
-} from "nostr-tools";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { concatBytes, randomBytes } from "@noble/hashes/utils.js";
+import { finalizeEvent, generateSecretKey, NostrEvent } from "nostr-tools";
 import { ClientState } from "ts-mls/clientState.js";
 import { CiphersuiteImpl } from "ts-mls/crypto/ciphersuite.js";
 import { mlsExporter } from "ts-mls/keySchedule.js";
@@ -15,42 +12,33 @@ import {
   type MlsMessage,
 } from "ts-mls/message.js";
 import { unixNow } from "../utils/nostr.js";
-import {
-  decryptBytes,
-  encryptBytes,
-  getConversationKey,
-} from "../utils/nip44-binary.js";
+import { decryptLegacyGroupMessageEventContent } from "./group-message-legacy.js";
 import { getNostrGroupIdHex } from "./client-state.js";
 import { isPrivateMessage } from "./message.js";
 import { GROUP_EVENT_KIND } from "./protocol.js";
 
 /**
- * Derives the NIP-44 conversation key for a group epoch.
+ * Derives the MIP-03 group-event encryption key for a group epoch.
  *
- * Uses the MLS Exporter (RFC 9420 §8.5) with label "nostr" and context "nostr"
- * to produce a 32-byte domain-separated secret from the epoch's exporter_secret.
- * That secret is then used as a secp256k1 private key; its corresponding public
- * key is used as the receiver, yielding a self-addressed NIP-44 conversation key
- * that is shared by all group members in the same epoch.
+ * Uses the MLS Exporter (RFC 9420 §8.5) with label "marmot" and context
+ * "group-event" to produce a 32-byte ChaCha20-Poly1305 key.
  */
-async function getGroupConversationKey(
+async function getGroupEventEncryptionKey(
   clientState: ClientState,
   ciphersuite: CiphersuiteImpl,
 ): Promise<Uint8Array> {
-  const nostrSecret = await mlsExporter(
+  return mlsExporter(
     clientState.keySchedule.exporterSecret,
-    "nostr",
-    new TextEncoder().encode("nostr"),
+    "marmot",
+    new TextEncoder().encode("group-event"),
     32,
     ciphersuite,
   );
-  const publicKey = getPublicKey(nostrSecret);
-  return getConversationKey(nostrSecret, publicKey);
 }
 
 /**
  * Reads a {@link NostrEvent} and returns the {@link MlsMessage} it contains.
- * Decrypts the NIP-44 encrypted content using the exporter_secret from the group state.
+ * Decrypts group-event encrypted content using the exporter_secret from the group state.
  *
  * @param message - The Nostr event containing the encrypted MLS message
  * @param clientState - The ClientState for the group (to get exporter_secret)
@@ -62,19 +50,43 @@ export async function decryptGroupMessageEvent(
   clientState: ClientState,
   ciphersuite: CiphersuiteImpl,
 ): Promise<MlsMessage> {
-  const conversationKey = await getGroupConversationKey(
-    clientState,
-    ciphersuite,
-  );
-  const serializedMessage = decryptBytes(message.content, conversationKey);
+  try {
+    const key = await getGroupEventEncryptionKey(clientState, ciphersuite);
+    const payload = decodeBase64(message.content);
+    if (payload.length < 12) {
+      throw new Error(
+        "Malformed group event content: expected at least 12 bytes",
+      );
+    }
 
-  const decoded = decode(mlsMessageDecoder, serializedMessage);
-  if (!decoded) throw new Error("Failed to decode MLS message");
-  return decoded;
+    const nonce = payload.subarray(0, 12);
+    const ciphertext = payload.subarray(12);
+    const serializedMessage = chacha20poly1305(
+      key,
+      nonce,
+      new Uint8Array(0),
+    ).decrypt(ciphertext);
+
+    const decoded = decode(mlsMessageDecoder, serializedMessage);
+    if (!decoded) throw new Error("Failed to decode MLS message");
+    return decoded;
+  } catch (primaryError) {
+    try {
+      return await decryptLegacyGroupMessageEventContent(
+        message.content,
+        clientState,
+        ciphersuite,
+      );
+    } catch (legacyError) {
+      throw new Error(
+        `Failed to decrypt group message (new format and legacy fallback failed): ${formatError(primaryError)}; legacy: ${formatError(legacyError)}`,
+      );
+    }
+  }
 }
 
 /**
- * Encrypts the content of a group event using NIP-44.
+ * Encrypts the content of a group event using MIP-03.
  *
  * @param state - The ClientState for the group (to get exporter_secret)
  * @param ciphersuite - The ciphersuite implementation
@@ -91,8 +103,12 @@ export async function createEncryptedGroupEventContent({
   message: MlsMessage;
 }): Promise<string> {
   const serializedMessage = encode(mlsMessageEncoder, message);
-  const conversationKey = await getGroupConversationKey(state, ciphersuite);
-  return encryptBytes(serializedMessage, conversationKey);
+  const key = await getGroupEventEncryptionKey(state, ciphersuite);
+  const nonce = randomBytes(12);
+  const ciphertext = chacha20poly1305(key, nonce, new Uint8Array(0)).encrypt(
+    serializedMessage,
+  );
+  return encodeBase64(concatBytes(nonce, ciphertext));
 }
 
 export type GroupMessagePair = {
@@ -320,4 +336,22 @@ export function isProposalMessage(
     isPrivateMessage(pair.message) &&
     pair.message.privateMessage.contentType === contentTypes.proposal
   );
+}
+
+function decodeBase64(value: string): Uint8Array {
+  try {
+    return Uint8Array.from(atob(value), (ch) => ch.charCodeAt(0));
+  } catch (error) {
+    throw new Error(
+      `Invalid base64 group event content: ${formatError(error)}`,
+    );
+  }
+}
+
+function encodeBase64(value: Uint8Array): string {
+  return btoa(String.fromCharCode(...value));
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/core/group-message.ts
+++ b/src/core/group-message.ts
@@ -11,6 +11,7 @@ import {
   mlsMessageEncoder,
   type MlsMessage,
 } from "ts-mls/message.js";
+import { decodeContent, encodeContent } from "../utils/encoding.js";
 import { unixNow } from "../utils/nostr.js";
 import { decryptLegacyGroupMessageEventContent } from "./group-message-legacy.js";
 import { getNostrGroupIdHex } from "./client-state.js";
@@ -340,7 +341,7 @@ export function isProposalMessage(
 
 function decodeBase64(value: string): Uint8Array {
   try {
-    return Uint8Array.from(atob(value), (ch) => ch.charCodeAt(0));
+    return decodeContent(value, "base64");
   } catch (error) {
     throw new Error(
       `Invalid base64 group event content: ${formatError(error)}`,
@@ -349,7 +350,7 @@ function decodeBase64(value: string): Uint8Array {
 }
 
 function encodeBase64(value: Uint8Array): string {
-  return btoa(String.fromCharCode(...value));
+  return encodeContent(value, "base64");
 }
 
 function formatError(error: unknown): string {

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,4 +1,5 @@
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+import { base64 } from "@scure/base";
 import { Rumor } from "applesauce-common/helpers/gift-wrap";
 import { NostrEvent } from "applesauce-core/helpers/event";
 
@@ -21,7 +22,7 @@ export function encodeContent(
   format: EncodingFormat,
 ): string {
   if (format === "base64") {
-    return btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(""));
+    return base64.encode(bytes);
   } else {
     // hex format
     return bytesToHex(bytes);
@@ -44,7 +45,7 @@ export function decodeContent(
 
   if (actualFormat === "base64") {
     try {
-      return Uint8Array.from(atob(content), (c) => c.charCodeAt(0));
+      return base64.decode(content);
     } catch (error) {
       throw new Error(
         `Failed to decode base64 content: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
PR to for https://github.com/marmot-protocol/marmot/pull/48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded group message encryption to MIP-03 (ChaCha20-Poly1305) with a legacy decryption fallback and deprecation warnings for old-format messages.
  * Stricter admin-commit policy with explicit rules for accepting commits and allowances for self-updates.

* **Tests**
  * Added extensive tests for MIP-03 encryption/decryption, legacy fallback behavior, and malformed payload handling.

* **Chores**
  * Replaced base64 handling with a new encoding library and added the dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->