### PR TITLE
fix(media): validate hex strings for nonce and sha256 fields

### DIFF
--- a/.changeset/honest-taxes-laugh.md
+++ b/.changeset/honest-taxes-laugh.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmot-ts": patch
+---
+
+Fix hex string validation and add deduplication for concurrent media decryption

--- a/src/__tests__/media.test.ts
+++ b/src/__tests__/media.test.ts
@@ -1,11 +1,17 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex, randomBytes } from "@noble/hashes/utils.js";
 import { defaultCryptoProvider, getCiphersuiteImpl } from "ts-mls";
-import { describe, expect, it } from "vitest";
+import type { NostrEvent } from "applesauce-core/helpers";
+import { describe, expect, it, vi } from "vitest";
 
+import { MarmotGroup } from "../client/group/marmot-group.js";
+import { GroupMediaStore } from "../client/group/group-media-store.js";
 import { createCredential } from "../core/credential.js";
 import { generateKeyPackage } from "../core/key-package.js";
 import { createSimpleGroup } from "../core/group.js";
+import { InMemoryKeyValueStore } from "../extra/in-memory-key-value-store.js";
+import { GroupStateStore } from "../store/group-state-store.js";
+import { KeyValueGroupStateBackend } from "../store/adapters/key-value-group-state-backend.js";
 import {
   canonicalizeMimeType,
   decryptMediaFile,
@@ -558,6 +564,18 @@ describe("parseMediaImetaTag", () => {
     expect(parseMediaImetaTag(tag)).toBeNull();
   });
 
+  it("returns null when n is not valid hex", () => {
+    const tag = [
+      "imeta",
+      "x " + bytesToHex(sha256(randomBytes(32))),
+      "m image/jpeg",
+      "filename photo.jpg",
+      "n zzzzzzzzzzzzzzzzzzzzzzzz",
+      "v " + MIP04_VERSION,
+    ];
+    expect(parseMediaImetaTag(tag)).toBeNull();
+  });
+
   it("returns null when x (sha256) is absent", () => {
     const tag = [
       "imeta",
@@ -573,6 +591,18 @@ describe("parseMediaImetaTag", () => {
     const tag = [
       "imeta",
       "x " + bytesToHex(randomBytes(31)), // 62 chars instead of 64
+      "m image/jpeg",
+      "filename photo.jpg",
+      "n " + bytesToHex(randomBytes(12)),
+      "v " + MIP04_VERSION,
+    ];
+    expect(parseMediaImetaTag(tag)).toBeNull();
+  });
+
+  it("returns null when x is not valid hex", () => {
+    const tag = [
+      "imeta",
+      "x " + "g".repeat(64),
       "m image/jpeg",
       "filename photo.jpg",
       "n " + bytesToHex(randomBytes(12)),
@@ -834,6 +864,20 @@ describe("getMediaAttachmentFromFileEvent", () => {
     expect(getMediaAttachmentFromFileEvent(event)).toBeNull();
   });
 
+  it("returns null when n is not valid hex", () => {
+    const event = buildKind1063Event({
+      sha256: bytesToHex(sha256(randomBytes(32))),
+      type: "image/jpeg",
+      filename: "photo.jpg",
+      nonce: bytesToHex(randomBytes(12)),
+      version: MIP04_VERSION,
+    });
+    event.tags = event.tags.map((t) =>
+      t[0] === "n" ? ["n", "zzzzzzzzzzzzzzzzzzzzzzzz"] : t,
+    );
+    expect(getMediaAttachmentFromFileEvent(event)).toBeNull();
+  });
+
   it("returns null when x (sha256) tag is absent", () => {
     const attachment: MediaAttachment = {
       sha256: bytesToHex(sha256(randomBytes(32))),
@@ -858,6 +902,20 @@ describe("getMediaAttachmentFromFileEvent", () => {
     // Replace x with a 31-byte (62 char) hash
     event.tags = event.tags.map((t) =>
       t[0] === "x" ? ["x", bytesToHex(randomBytes(31))] : t,
+    );
+    expect(getMediaAttachmentFromFileEvent(event)).toBeNull();
+  });
+
+  it("returns null when x is not valid hex", () => {
+    const event = buildKind1063Event({
+      sha256: bytesToHex(sha256(randomBytes(32))),
+      type: "image/jpeg",
+      filename: "photo.jpg",
+      nonce: bytesToHex(randomBytes(12)),
+      version: MIP04_VERSION,
+    });
+    event.tags = event.tags.map((t) =>
+      t[0] === "x" ? ["x", "g".repeat(64)] : t,
     );
     expect(getMediaAttachmentFromFileEvent(event)).toBeNull();
   });
@@ -949,5 +1007,54 @@ describe("getMediaAttachmentFromFileEvent", () => {
     expect(result!.size).toBe(8192);
     expect(result!.type).toBe("video/mp4");
     expect(result!.sha256).toBe(sha);
+  });
+});
+
+describe("MarmotGroup.decryptMedia", () => {
+  it("deduplicates concurrent decrypts for the same attachment", async () => {
+    const { clientState, ciphersuite } = await makeClientState();
+    const stateStore = new GroupStateStore(
+      new KeyValueGroupStateBackend(new InMemoryKeyValueStore()),
+    );
+    const group = new MarmotGroup(clientState, {
+      stateStore,
+      signer: {
+        getPublicKey: async () => "a".repeat(64),
+        signEvent: async (event) => event as NostrEvent,
+      },
+      ciphersuite,
+      media: new GroupMediaStore(),
+      network: {
+        request: async () => [],
+        subscription: () => {
+          throw new Error("not implemented");
+        },
+        publish: async () => ({}),
+        getUserInboxRelays: async () => [],
+      },
+    });
+
+    const file = randomBytes(128);
+    const attachment = makeAttachment(file, "image/png", "image.png");
+    const fileKey = await deriveMediaEncryptionKey(
+      clientState,
+      ciphersuite,
+      attachment,
+    );
+    const { encrypted, attachment: filled } = encryptMediaFile(
+      file,
+      fileKey,
+      attachment,
+    );
+
+    const addMediaSpy = vi.spyOn(group.media, "addMedia");
+    const [first, second] = await Promise.all([
+      group.decryptMedia(encrypted, filled),
+      group.decryptMedia(encrypted, filled),
+    ]);
+
+    expect(first.data).toEqual(file);
+    expect(second.data).toEqual(file);
+    expect(addMediaSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/client/group/marmot-group.ts
+++ b/src/client/group/marmot-group.ts
@@ -325,6 +325,9 @@ export class MarmotGroup<
    */
   readonly #sentEventIds = new Set<string>();
 
+  /** In-flight media decrypts keyed by plaintext SHA-256 hex. */
+  readonly #decryptingMedia = new Map<string, Promise<StoredMedia>>();
+
   get id() {
     return this.state.groupContext.groupId;
   }
@@ -1470,21 +1473,32 @@ export class MarmotGroup<
     const cached = await this.media?.getMedia(attachment.sha256);
     if (cached) return cached;
 
-    // Cache miss — derive key and decrypt
-    const fileKey = await deriveMediaEncryptionKey(
-      this.state,
-      this.ciphersuite,
-      attachment,
-    );
-    const plaintext = decryptMediaFile(encrypted, fileKey, attachment);
+    const inFlight = this.#decryptingMedia.get(attachment.sha256);
+    if (inFlight) return inFlight;
 
-    // Populate cache for future calls
-    await this.media?.addMedia(attachment.sha256, {
-      data: plaintext,
-      attachment,
-    });
+    const decryptPromise = (async () => {
+      const fileKey = await deriveMediaEncryptionKey(
+        this.state,
+        this.ciphersuite,
+        attachment,
+      );
+      const plaintext = decryptMediaFile(encrypted, fileKey, attachment);
 
-    return { data: plaintext, attachment };
+      await this.media?.addMedia(attachment.sha256, {
+        data: plaintext,
+        attachment,
+      });
+
+      return { data: plaintext, attachment };
+    })();
+
+    this.#decryptingMedia.set(attachment.sha256, decryptPromise);
+
+    try {
+      return await decryptPromise;
+    } finally {
+      this.#decryptingMedia.delete(attachment.sha256);
+    }
   }
 
   /** Destroys the group and purges the group history */

--- a/src/core/media.ts
+++ b/src/core/media.ts
@@ -327,6 +327,15 @@ function isValidMimeType(value: string): boolean {
   return slash > 0 && slash < bare.length - 1;
 }
 
+/**
+ * Returns true iff `value` is valid hex with the expected encoded byte length.
+ *
+ * @internal
+ */
+function isValidHex(value: string, expectedBytes: number): boolean {
+  return value.length === expectedBytes * 2 && /^[0-9a-f]+$/i.test(value);
+}
+
 // ---------------------------------------------------------------------------
 // Internal imeta parser
 // ---------------------------------------------------------------------------
@@ -385,15 +394,13 @@ export function parseMediaImetaTag(tag: string[]): MediaAttachment | null {
   const filename = raw.get("filename");
 
   if (version !== MIP04_VERSION) return null;
-  // n encodes a 12-byte nonce as hex → must be exactly 24 characters
-  if (!nonce || nonce.length !== 24) return null;
+  if (!nonce || !isValidHex(nonce, 12)) return null;
   if (!filename || filename.length === 0) return null;
 
   // Delegate standard NIP-92 field parsing to applesauce.
   const base = getFileMetadataFromImetaTag(tag);
 
-  // x encodes a 32-byte SHA-256 as hex → must be exactly 64 characters
-  if (!base.sha256 || base.sha256.length !== 64) return null;
+  if (!base.sha256 || !isValidHex(base.sha256, 32)) return null;
   // m must be a valid MIME type
   if (!base.type || !isValidMimeType(base.type)) return null;
 
@@ -454,15 +461,13 @@ export function getMediaAttachmentFromFileEvent(
   const filename = getTag("filename");
 
   if (version !== MIP04_VERSION) return null;
-  // n encodes a 12-byte nonce as hex → must be exactly 24 characters
-  if (!nonce || nonce.length !== 24) return null;
+  if (!nonce || !isValidHex(nonce, 12)) return null;
   if (!filename || filename.length === 0) return null;
 
   // Delegate standard NIP-94 tag parsing to applesauce.
   const base = getFileMetadata(event);
 
-  // x encodes a 32-byte SHA-256 as hex → must be exactly 64 characters
-  if (!base.sha256 || base.sha256.length !== 64) return null;
+  if (!base.sha256 || !isValidHex(base.sha256, 32)) return null;
   // m must be a valid MIME type
   if (!base.type || !isValidMimeType(base.type)) return null;
 


### PR DESCRIPTION
Add isValidHex helper to properly validate that nonce (12 bytes) and sha256 (32 bytes) values are valid hex strings. Previously, only length checks were performed, which allowed non-hex characters to pass validation.

Also adds deduplication for concurrent decryptMedia calls to prevent redundant decryption operations for the same attachment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hex string validation for media-related fields
  * Enhanced handling of concurrent media decryption to prevent duplicate processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->