### PR TITLE
Save client state after creating proposal

### DIFF
--- a/.changeset/twelve-nails-move.md
+++ b/.changeset/twelve-nails-move.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmot-ts": patch
+---
+
+Fix: save state after sending proposal

--- a/.changeset/wet-nails-lick.md
+++ b/.changeset/wet-nails-lick.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmot-ts": minor
+---
+
+Remove unused `MarmotGroup.publish` method

--- a/src/client/group/marmot-group.ts
+++ b/src/client/group/marmot-group.ts
@@ -391,6 +391,7 @@ export class MarmotGroup<
       this.history = undefined as THistory;
     }
 
+    // Create the media store
     if (options.media) {
       if (typeof options.media === "function") {
         this.media = options.media(this.id);
@@ -438,13 +439,6 @@ export class MarmotGroup<
     this.emit("stateSaved", this);
   }
 
-  /** Publish an event to the group relays */
-  async publish(event: NostrEvent): Promise<Record<string, PublishResponse>> {
-    const relays = this.relays;
-    if (!relays) throw new NoGroupRelaysError();
-    return await this.network.publish(relays, event);
-  }
-
   /**
    * Performs a self-update commit (no proposals) to rotate this member's leaf key material.
    *
@@ -480,9 +474,8 @@ export class MarmotGroup<
     });
 
     const response = await this.network.publish(relays, commitEvent);
-    if (!hasAck(response)) {
+    if (!hasAck(response))
       throw new Error("Failed to publish commit event: no relay acknowledged");
-    }
 
     // Advance local state after publish.
     this.state = newState;
@@ -543,12 +536,7 @@ export class MarmotGroup<
   async sendProposal(
     proposal: Proposal,
   ): Promise<Record<string, PublishResponse>> {
-    // NOTE: We don't update state here because:
-    // 1. The proposal will be received back from relays and processed via ingest()
-    // 2. When processed via ingest(), it will be added to state.unappliedProposals
-    // 3. If you need to commit immediately with this proposal, pass it explicitly to commit()
-    // In v2, createProposal takes a single params object with context
-    const { message } = await createProposal({
+    const { message, newState } = await createProposal({
       context: {
         cipherSuite: this.ciphersuite,
         authService: marmotAuthService,
@@ -559,6 +547,9 @@ export class MarmotGroup<
       wireAsPublicMessage: false,
     });
 
+    // Update the group state after successful publish
+    this.state = newState;
+
     // Wrap the message in a group event
     const proposalEvent = await createGroupEvent({
       message,
@@ -567,7 +558,9 @@ export class MarmotGroup<
     });
 
     // Publish to the group's relays
-    return await this.publish(proposalEvent);
+    const relays = this.relays;
+    if (!relays) throw new NoGroupRelaysError();
+    return await this.network.publish(relays, proposalEvent);
   }
 
   /**
@@ -599,13 +592,10 @@ export class MarmotGroup<
       message: applicationData,
     });
 
-    // The message returned is the MLS message (not privateMessage directly)
-    const mlsMessage = message;
-
     // Wrap the message in a group event
     // Use this.state (not newState) to get the exporter_secret for the current epoch
     const applicationEvent = await createGroupEvent({
-      message: mlsMessage,
+      message,
       state: this.state,
       ciphersuite: this.ciphersuite,
     });
@@ -1465,9 +1455,8 @@ export class MarmotGroup<
     encrypted: Uint8Array,
     attachment: MediaAttachment,
   ): Promise<StoredMedia> {
-    if (!attachment.sha256) {
+    if (!attachment.sha256)
       throw new Error("decryptMedia: attachment.sha256 is required");
-    }
 
     // Cache hit — return immediately without re-deriving the key
     const cached = await this.media?.getMedia(attachment.sha256);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state not being saved properly after sending proposals

* **Breaking Changes**
  * Removed the unused publish method from the group API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->