### PR TITLE
fix(group): ensure proposal events are acknowledged before advancing state

### DIFF
--- a/.changeset/many-dots-brake.md
+++ b/.changeset/many-dots-brake.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmot-ts": patch
+---
+
+Fix leave proposal state handling to persist only after relay acknowledgement

--- a/src/__tests__/integration/ingest-commit-race.test.ts
+++ b/src/__tests__/integration/ingest-commit-race.test.ts
@@ -20,13 +20,15 @@ import { MarmotGroup } from "../../client/group/marmot-group.js";
 import type { NostrNetworkInterface } from "../../client/nostr-interface.js";
 import { SerializedClientState } from "../../core/client-state.js";
 import { createCredential } from "../../core/credential.js";
-import { createGroupEvent, sortGroupCommits } from "../../core/group-message.js";
+import {
+  createGroupEvent,
+  sortGroupCommits,
+} from "../../core/group-message.js";
 import { createSimpleGroup } from "../../core/group.js";
 import { generateKeyPackage } from "../../core/key-package.js";
 import { GroupStateStore } from "../../store/group-state-store.js";
 import { KeyValueGroupStateBackend } from "../../store/adapters/key-value-group-state-backend.js";
 import { MemoryBackend } from "../helpers/memory-backend.js";
-
 
 async function createTestGroupState(
   adminPubkey: string,

--- a/src/client/__tests__/key-package-manager.test.ts
+++ b/src/client/__tests__/key-package-manager.test.ts
@@ -11,6 +11,9 @@ import {
 import type { KeyValueStoreBackend } from "../../utils/key-value.js";
 import { MockNetwork } from "../../__tests__/helpers/mock-network.js";
 import { MemoryBackend } from "../../__tests__/helpers/memory-backend.js";
+import { generateKeyPackage } from "../../core/key-package.js";
+import { createCredential } from "../../core/credential.js";
+import { defaultCryptoProvider, getCiphersuiteImpl } from "ts-mls";
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -144,10 +147,6 @@ describe("KeyPackageManager", () => {
       const { manager, store } = makeManager(network, account);
 
       // Add a key package to the private store without any published events
-      const { generateKeyPackage } = await import("../../core/key-package.js");
-      const { createCredential } = await import("../../core/credential.js");
-      const { defaultCryptoProvider, getCiphersuiteImpl } =
-        await import("ts-mls");
       const ciphersuite = await getCiphersuiteImpl(
         "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
         defaultCryptoProvider,
@@ -236,10 +235,6 @@ describe("KeyPackageManager", () => {
       const { manager, store } = makeManager(network, account);
 
       // Add an unpublished key package directly to the private store
-      const { generateKeyPackage } = await import("../../core/key-package.js");
-      const { createCredential } = await import("../../core/credential.js");
-      const { defaultCryptoProvider, getCiphersuiteImpl } =
-        await import("ts-mls");
       const ciphersuite = await getCiphersuiteImpl(
         "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
         defaultCryptoProvider,
@@ -391,10 +386,6 @@ describe("KeyPackageManager", () => {
       const { manager, store } = makeManager(network, account);
 
       // Add an unpublished key package directly to the private store
-      const { generateKeyPackage } = await import("../../core/key-package.js");
-      const { createCredential } = await import("../../core/credential.js");
-      const { defaultCryptoProvider, getCiphersuiteImpl } =
-        await import("ts-mls");
       const ciphersuite = await getCiphersuiteImpl(
         "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
         defaultCryptoProvider,
@@ -653,10 +644,6 @@ describe("KeyPackageManager", () => {
       await manager.create({ relays: ["wss://relay.test"] });
 
       // One unpublished package (added directly to private store, no publish record)
-      const { generateKeyPackage } = await import("../../core/key-package.js");
-      const { createCredential } = await import("../../core/credential.js");
-      const { defaultCryptoProvider, getCiphersuiteImpl } =
-        await import("ts-mls");
       const ciphersuite = await getCiphersuiteImpl(
         "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
         defaultCryptoProvider,

--- a/src/client/__tests__/leave-group.test.ts
+++ b/src/client/__tests__/leave-group.test.ts
@@ -8,6 +8,7 @@ import { KeyValueGroupStateBackend } from "../../store/adapters/key-value-group-
 import { KeyPackageStore } from "../../store/key-package-store.js";
 import { MockNetwork } from "../../__tests__/helpers/mock-network.js";
 import { MemoryBackend } from "../../__tests__/helpers/memory-backend.js";
+import { unlockGiftWrap } from "applesauce-common/helpers";
 
 // ============================================================================
 // Shared setup helpers
@@ -60,8 +61,6 @@ async function setupTwoMemberGroup(mockNetwork: MockNetwork) {
   await adminGroup.inviteByKeyPackageEvent(keyPackageEvents[0]);
 
   // Member joins from the welcome
-  const { unlockGiftWrap } =
-    await import("applesauce-common/helpers/gift-wrap");
   const giftWraps = await mockNetwork.request(["wss://mock-inbox.test"], {
     kinds: [1059],
     "#p": [memberPubkey],
@@ -92,21 +91,21 @@ describe("MarmotGroup.leave()", () => {
     mockNetwork = new MockNetwork();
   });
 
-  it("publishes a leave commit event to group relays", async () => {
+  it("publishes a leave proposal event to group relays", async () => {
     const { memberGroup } = await setupTwoMemberGroup(mockNetwork);
 
-    const commitCountBefore = mockNetwork.events.filter(
+    const proposalCountBefore = mockNetwork.events.filter(
       (e) => e.kind === GROUP_EVENT_KIND,
     ).length;
 
     await memberGroup.leave();
 
-    const commitCountAfter = mockNetwork.events.filter(
+    const proposalCountAfter = mockNetwork.events.filter(
       (e) => e.kind === GROUP_EVENT_KIND,
     ).length;
 
-    // One new group event published for the leave commit
-    expect(commitCountAfter).toBe(commitCountBefore + 1);
+    // One new group event published for the leave proposal
+    expect(proposalCountAfter).toBe(proposalCountBefore + 1);
   });
 
   it("destroys local group state (store is empty after leave)", async () => {
@@ -174,10 +173,7 @@ describe("MarmotGroup.leave()", () => {
     expect(groupsAfter.some((id) => bytesToHex(id) === groupIdHex)).toBe(true);
   });
 
-  it("throws NoMarmotGroupDataError when group data is missing", async () => {
-    // Create a minimal group with no group data by using the admin's group
-    // without the marmot extension — instead, just check the error fires for
-    // a group with no relays configured.
+  it("throws when relays are missing", async () => {
     const { memberGroup } = await setupTwoMemberGroup(mockNetwork);
 
     // Monkeypatch relays to simulate missing relay config
@@ -196,7 +192,7 @@ describe("MarmotClient.leaveGroup()", () => {
     mockNetwork = new MockNetwork();
   });
 
-  it("publishes a leave commit and evicts the group from the client cache", async () => {
+  it("publishes leave proposal events and evicts the group from the client cache", async () => {
     const { memberClient, memberGroup } =
       await setupTwoMemberGroup(mockNetwork);
 
@@ -248,21 +244,21 @@ describe("MarmotClient.leaveGroup()", () => {
     await expect(memberClient.leaveGroup(hexId)).resolves.toBeDefined();
   });
 
-  it("publishes a commit event to the group relays", async () => {
+  it("publishes a proposal event to the group relays", async () => {
     const { memberClient, memberGroup } =
       await setupTwoMemberGroup(mockNetwork);
 
     const groupIdHex = bytesToHex(memberGroup.id);
-    const commitsBefore = mockNetwork.events.filter(
+    const proposalsBefore = mockNetwork.events.filter(
       (e) => e.kind === GROUP_EVENT_KIND,
     ).length;
 
     await memberClient.leaveGroup(memberGroup.id);
 
-    const commitsAfter = mockNetwork.events.filter(
+    const proposalsAfter = mockNetwork.events.filter(
       (e) => e.kind === GROUP_EVENT_KIND,
     ).length;
 
-    expect(commitsAfter).toBe(commitsBefore + 1);
+    expect(proposalsAfter).toBe(proposalsBefore + 1);
   });
 });

--- a/src/client/group/marmot-group.ts
+++ b/src/client/group/marmot-group.ts
@@ -600,9 +600,6 @@ export class MarmotGroup<
       wireAsPublicMessage: false,
     });
 
-    // Update the group state after successful publish
-    this.state = newState;
-
     // Wrap the message in a group event
     const proposalEvent = await createGroupEvent({
       message,
@@ -613,7 +610,19 @@ export class MarmotGroup<
     // Publish to the group's relays
     const relays = this.relays;
     if (!relays) throw new NoGroupRelaysError();
-    return await this.network.publish(relays, proposalEvent);
+
+    const response = await this.network.publish(relays, proposalEvent);
+    if (!hasAck(response)) {
+      throw new Error(
+        "Failed to publish proposal event: no relay acknowledged",
+      );
+    }
+
+    // Advance local state only after at least one relay acknowledges the event.
+    this.state = newState;
+    await this.save();
+
+    return response;
   }
 
   /**

--- a/src/client/key-package-manager.ts
+++ b/src/client/key-package-manager.ts
@@ -2,7 +2,7 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 import { EventSigner } from "applesauce-core";
 import { NostrEvent } from "applesauce-core/helpers/event";
 import { EventEmitter } from "eventemitter3";
-import { CiphersuiteName } from "ts-mls/crypto/ciphersuite.js";
+import { CiphersuiteName, ciphersuites } from "ts-mls/crypto/ciphersuite.js";
 import { PrivateKeyPackage } from "ts-mls/keyPackage.js";
 import { createCredential } from "../core/credential.js";
 import {
@@ -20,6 +20,7 @@ import {
 } from "../store/key-package-store.js";
 import { NostrNetworkInterface } from "./nostr-interface.js";
 import { logger } from "../utils/debug.js";
+import { defaultCryptoProvider } from "ts-mls";
 
 /**
  * Thrown by {@link KeyPackageManager.create} when no relay URLs are provided.
@@ -536,8 +537,6 @@ export class KeyPackageManager extends EventEmitter<KeyPackageManagerEvents> {
   }
 
   async #getCiphersuiteImpl(name?: CiphersuiteName) {
-    const { defaultCryptoProvider } = await import("ts-mls");
-    const { ciphersuites } = await import("ts-mls/crypto/ciphersuite.js");
     const ciphersuiteName =
       name ?? "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519";
     const id = ciphersuites[ciphersuiteName];

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -45,7 +45,7 @@ import {
   MarmotGroup,
 } from "./group/marmot-group.js";
 import { KeyPackageManager } from "./key-package-manager.js";
-import { NostrNetworkInterface, PublishResponse } from "./nostr-interface.js";
+import type { NostrNetworkInterface, PublishResponse } from "./nostr-interface.js";
 
 const log = logger.extend("client");
 

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -45,7 +45,7 @@ import {
   MarmotGroup,
 } from "./group/marmot-group.js";
 import { KeyPackageManager } from "./key-package-manager.js";
-import { NostrNetworkInterface } from "./nostr-interface.js";
+import { NostrNetworkInterface, PublishResponse } from "./nostr-interface.js";
 
 const log = logger.extend("client");
 
@@ -96,7 +96,7 @@ type MarmotClientEvents<
   groupUnloaded: (groupId: Uint8Array) => void;
   /** Emitted when a group is destroyed */
   groupDestroyed: (groupId: Uint8Array) => void;
-  /** Emitted when the client leaves a group via a self-remove commit */
+  /** Emitted when the client leaves a group via self-remove proposal events */
   groupLeft: (groupId: Uint8Array) => void;
 };
 
@@ -331,7 +331,7 @@ export class MarmotClient<
    */
   async leaveGroup(
     groupId: Uint8Array | string,
-  ): Promise<Record<string, import("./nostr-interface.js").PublishResponse>> {
+  ): Promise<Record<string, PublishResponse>> {
     const id = typeof groupId === "string" ? groupId : bytesToHex(groupId);
     log("leaving group %s", id);
 
@@ -341,7 +341,7 @@ export class MarmotClient<
     const groupIdBytes =
       typeof groupId === "string" ? hexToBytes(groupId) : groupId;
 
-    // Publish the self-remove commit and destroy local state.
+    // Publish the self-remove proposal events and destroy local state.
     const response = await group.leave();
 
     // Evict from the in-memory cache (destroy() already removed from store).


### PR DESCRIPTION
- Convert dynamic imports to static imports for consistency
- Update terminology from "commit" to "proposal" in tests and comments
- Add acknowledgment check before updating local group state to prevent state desync when relays don't acknowledge published proposal events
- Call save() after state advancement to persist the updated state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure proposal state is advanced and persisted only after a relay acknowledges the publish.

* **Documentation**
  * Clarified event wording to consistently use "proposal" and added a changeset noting the leave-proposal persistence fix.

* **Chores**
  * Updated import patterns and adjusted a public method's return typing for clearer usage.

* **Tests**
  * Reformatted and renamed tests to reflect proposal terminology and moved some imports for consistency.

* **Chores**
  * Updated recorded submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->