### PR TITLE
fix: forward MarmotClient capabilities to KeyPackageManager

### DIFF
--- a/.changeset/forward-client-capabilities-to-key-packages.md
+++ b/.changeset/forward-client-capabilities-to-key-packages.md
@@ -1,0 +1,5 @@
+---
+"@internet-privacy/marmot-ts": patch
+---
+
+Forward the `MarmotClient` `capabilities` option to `KeyPackageManager` so custom capabilities (such as adding SelfRemove proposal type `0x000A` for Amethyst interop) are reflected in generated key packages instead of being silently ignored.

--- a/src/client/key-package-manager.ts
+++ b/src/client/key-package-manager.ts
@@ -4,6 +4,7 @@ import { EventSigner } from "applesauce-core";
 import { NostrEvent } from "applesauce-core/helpers/event";
 import { EventEmitter } from "eventemitter3";
 import {
+  Capabilities,
   CiphersuiteName,
   ciphersuites,
   CryptoProvider,
@@ -265,6 +266,8 @@ export type KeyPackageManagerOptions = {
   network: NostrNetworkInterface;
   /** The crypto provider to use for cryptographic operations */
   cryptoProvider?: CryptoProvider;
+  /** Capabilities to advertise in generated key packages. Falls back to ts-mls `defaultCapabilities()` when omitted. */
+  capabilities?: Capabilities;
 };
 
 /**
@@ -287,6 +290,7 @@ export class KeyPackageManager extends EventEmitter<KeyPackageManagerEvents> {
   private readonly cryptoProvider: CryptoProvider;
   private readonly signer: EventSigner;
   private readonly network: NostrNetworkInterface;
+  private readonly capabilities: Capabilities | undefined;
 
   #log = logger.extend("KeyPackageManager");
 
@@ -297,6 +301,7 @@ export class KeyPackageManager extends EventEmitter<KeyPackageManagerEvents> {
     this.signer = options.signer;
     this.network = options.network;
     this.clientId = options.clientId;
+    this.capabilities = options.capabilities;
   }
 
   // ---------------------------------------------------------------------------
@@ -506,6 +511,7 @@ export class KeyPackageManager extends EventEmitter<KeyPackageManagerEvents> {
       credential,
       ciphersuiteImpl: ciphersuite,
       isLastResort: options.isLastResort,
+      capabilities: this.capabilities,
     });
 
     // Store private material locally, including the slot identifier

--- a/src/client/marmot-client.ts
+++ b/src/client/marmot-client.ts
@@ -106,6 +106,7 @@ export class MarmotClient<
       signer: options.signer,
       network: options.network,
       clientId: options.clientId,
+      capabilities: this.capabilities,
     });
 
     const historyFactory = (


### PR DESCRIPTION
The capabilities option on MarmotClient was stored on the instance but never passed to KeyPackageManager, so generateKeyPackage() always fell back to defaultCapabilities(). Custom capabilities (e.g. SelfRemove proposal 0x000A required by Amethyst for MDK interop) were silently ignored. Forward this.capabilities to KeyPackageManager and through to generateKeyPackage() in create() (which also covers rotate()).

See https://github.com/marmot-protocol/marmot-ts/issues/73

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/marmot-ts/pull/74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Client capabilities are now properly applied during key package generation, ensuring custom configuration is respected throughout the lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/marmot-ts/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->